### PR TITLE
fix: resolve "Cannot access basePath before initialization" error

### DIFF
--- a/openapi-generator-config.json
+++ b/openapi-generator-config.json
@@ -1,7 +1,7 @@
 {
   "supportsES6": true,
   "npmName": "@meeting-baas/sdk",
-  "npmVersion": "4.0.3",
+  "npmVersion": "4.0.4",
   "modelPropertyNaming": "camelCase",
   "enumPropertyNaming": "camelCase",
   "withSeparateModelsAndApi": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeting-baas/sdk",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Official SDK for Meeting BaaS API - https://meetingbaas.com",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/rules/openapi-generator/openapi-generator-readme.md
+++ b/rules/openapi-generator/openapi-generator-readme.md
@@ -1,6 +1,6 @@
-              GitHub - OpenAPITools/openapi-generator: OpenAPI Generator allows generation of API client libraries (SDK generation), server stubs, documentation and configuration automatically given an OpenAPI Spec (v2, v3)                                         
+              GitHub - OpenAPITools/openapi-generator: OpenAPI Generator allows generation of API client libraries (SDK generation), server stubs, documentation and configuration automatically given an OpenAPI Spec (v2, v3)
 
-[Skip to content](#start-of-content)  
+[Skip to content](#start-of-content)
 
 ## Navigation Menu
 
@@ -10,176 +10,185 @@ Toggle navigation
 
 [Sign in](/login?return_to=https%3A%2F%2Fgithub.com%2FOpenAPITools%2Fopenapi-generator)
 
--   Product
-    
-    -   [
-        
-        GitHub Copilot
-        
-        Write better code with AI
-        
-        ](https://github.com/features/copilot)
-    -   [
-        
-        Security
-        
-        Find and fix vulnerabilities
-        
-        ](https://github.com/features/security)
-    -   [
-        
-        Actions
-        
-        Automate any workflow
-        
-        ](https://github.com/features/actions)
-    -   [
-        
-        Codespaces
-        
-        Instant dev environments
-        
-        ](https://github.com/features/codespaces)
-    -   [
-        
-        Issues
-        
-        Plan and track work
-        
-        ](https://github.com/features/issues)
-    -   [
-        
-        Code Review
-        
-        Manage code changes
-        
-        ](https://github.com/features/code-review)
-    -   [
-        
-        Discussions
-        
-        Collaborate outside of code
-        
-        ](https://github.com/features/discussions)
-    -   [
-        
-        Code Search
-        
-        Find more, search less
-        
-        ](https://github.com/features/code-search)
-    
-    Explore
-    
-    -   [All features](https://github.com/features)
-    -   [Documentation](https://docs.github.com)
-    -   [GitHub Skills](https://skills.github.com)
-    -   [Blog](https://github.blog)
-    
--   Solutions
-    
-    By company size
-    
-    -   [Enterprises](https://github.com/enterprise)
-    -   [Small and medium teams](https://github.com/team)
-    -   [Startups](https://github.com/enterprise/startups)
-    -   [Nonprofits](/solutions/industry/nonprofits)
-    
-    By use case
-    
-    -   [DevSecOps](/solutions/use-case/devsecops)
-    -   [DevOps](/solutions/use-case/devops)
-    -   [CI/CD](/solutions/use-case/ci-cd)
-    -   [View all use cases](/solutions/use-case)
-    
-    By industry
-    
-    -   [Healthcare](/solutions/industry/healthcare)
-    -   [Financial services](/solutions/industry/financial-services)
-    -   [Manufacturing](/solutions/industry/manufacturing)
-    -   [Government](/solutions/industry/government)
-    -   [View all industries](/solutions/industry)
-    
-    [View all solutions](/solutions)
-    
--   Resources
-    
-    Topics
-    
-    -   [AI](/resources/articles/ai)
-    -   [DevOps](/resources/articles/devops)
-    -   [Security](/resources/articles/security)
-    -   [Software Development](/resources/articles/software-development)
-    -   [View all](/resources/articles)
-    
-    Explore
-    
-    -   [Learning Pathways](https://resources.github.com/learn/pathways)
-    -   [Events & Webinars](https://resources.github.com)
-    -   [Ebooks & Whitepapers](https://github.com/resources/whitepapers)
-    -   [Customer Stories](https://github.com/customer-stories)
-    -   [Partners](https://partner.github.com)
-    -   [Executive Insights](https://github.com/solutions/executive-insights)
-    
--   Open Source
-    
-    -   [
-        
-        GitHub Sponsors
-        
-        Fund open source developers
-        
-        ](/sponsors)
-    
-    -   [
-        
-        The ReadME Project
-        
-        GitHub community articles
-        
-        ](https://github.com/readme)
-    
-    Repositories
-    
-    -   [Topics](https://github.com/topics)
-    -   [Trending](https://github.com/trending)
-    -   [Collections](https://github.com/collections)
-    
--   Enterprise
-    
-    -   [
-        
-        Enterprise platform
-        
-        AI-powered developer platform
-        
-        ](/enterprise)
-    
-    Available add-ons
-    
-    -   [
-        
-        Advanced Security
-        
-        Enterprise-grade security features
-        
-        ](https://github.com/enterprise/advanced-security)
-    -   [
-        
-        Copilot for business
-        
-        Enterprise-grade AI features
-        
-        ](/features/copilot/copilot-business)
-    -   [
-        
-        Premium Support
-        
-        Enterprise-grade 24/7 support
-        
-        ](/premium-support)
-    
--   [Pricing](https://github.com/pricing)
+- Product
+
+  - [
+
+    GitHub Copilot
+
+    Write better code with AI
+
+    ](https://github.com/features/copilot)
+
+  - [
+
+    Security
+
+    Find and fix vulnerabilities
+
+    ](https://github.com/features/security)
+
+  - [
+
+    Actions
+
+    Automate any workflow
+
+    ](https://github.com/features/actions)
+
+  - [
+
+    Codespaces
+
+    Instant dev environments
+
+    ](https://github.com/features/codespaces)
+
+  - [
+
+    Issues
+
+    Plan and track work
+
+    ](https://github.com/features/issues)
+
+  - [
+
+    Code Review
+
+    Manage code changes
+
+    ](https://github.com/features/code-review)
+
+  - [
+
+    Discussions
+
+    Collaborate outside of code
+
+    ](https://github.com/features/discussions)
+
+  - [
+
+    Code Search
+
+    Find more, search less
+
+    ](https://github.com/features/code-search)
+
+  Explore
+
+  - [All features](https://github.com/features)
+  - [Documentation](https://docs.github.com)
+  - [GitHub Skills](https://skills.github.com)
+  - [Blog](https://github.blog)
+
+- Solutions
+
+  By company size
+
+  - [Enterprises](https://github.com/enterprise)
+  - [Small and medium teams](https://github.com/team)
+  - [Startups](https://github.com/enterprise/startups)
+  - [Nonprofits](/solutions/industry/nonprofits)
+
+  By use case
+
+  - [DevSecOps](/solutions/use-case/devsecops)
+  - [DevOps](/solutions/use-case/devops)
+  - [CI/CD](/solutions/use-case/ci-cd)
+  - [View all use cases](/solutions/use-case)
+
+  By industry
+
+  - [Healthcare](/solutions/industry/healthcare)
+  - [Financial services](/solutions/industry/financial-services)
+  - [Manufacturing](/solutions/industry/manufacturing)
+  - [Government](/solutions/industry/government)
+  - [View all industries](/solutions/industry)
+
+  [View all solutions](/solutions)
+
+- Resources
+
+  Topics
+
+  - [AI](/resources/articles/ai)
+  - [DevOps](/resources/articles/devops)
+  - [Security](/resources/articles/security)
+  - [Software Development](/resources/articles/software-development)
+  - [View all](/resources/articles)
+
+  Explore
+
+  - [Learning Pathways](https://resources.github.com/learn/pathways)
+  - [Events & Webinars](https://resources.github.com)
+  - [Ebooks & Whitepapers](https://github.com/resources/whitepapers)
+  - [Customer Stories](https://github.com/customer-stories)
+  - [Partners](https://partner.github.com)
+  - [Executive Insights](https://github.com/solutions/executive-insights)
+
+- Open Source
+
+  - [
+
+    GitHub Sponsors
+
+    Fund open source developers
+
+    ](/sponsors)
+
+  - [
+
+    The ReadME Project
+
+    GitHub community articles
+
+    ](https://github.com/readme)
+
+  Repositories
+
+  - [Topics](https://github.com/topics)
+  - [Trending](https://github.com/trending)
+  - [Collections](https://github.com/collections)
+
+- Enterprise
+
+  - [
+
+    Enterprise platform
+
+    AI-powered developer platform
+
+    ](/enterprise)
+
+  Available add-ons
+
+  - [
+
+    Advanced Security
+
+    Enterprise-grade security features
+
+    ](https://github.com/enterprise/advanced-security)
+
+  - [
+
+    Copilot for business
+
+    Enterprise-grade AI features
+
+    ](/features/copilot/copilot-business)
+
+  - [
+
+    Premium Support
+
+    Enterprise-grade 24/7 support
+
+    ](/premium-support)
+
+- [Pricing](https://github.com/pricing)
 
 Search or jump to...
 
@@ -195,7 +204,7 @@ Clear
 
 We read every piece of feedback, and take your input very seriously.
 
- Include my email address so I can be contacted
+Include my email address so I can be contacted
 
 Cancel Submit feedback
 
@@ -203,9 +212,9 @@ Cancel Submit feedback
 
 ## Use saved searches to filter your results more quickly
 
-Name  
+Name
 
-Query 
+Query
 
 To see all available qualifiers, see our [documentation](https://docs.github.com/search-github/github-code-search/understanding-github-code-search-syntax).
 
@@ -219,10 +228,9 @@ You signed in with another tab or window. Reload to refresh your session. You si
 
 [OpenAPITools](/OpenAPITools) / **[openapi-generator](/OpenAPITools/openapi-generator)** Public
 
--   [Notifications](/login?return_to=%2FOpenAPITools%2Fopenapi-generator) You must be signed in to change notification settings
--   [Fork 6.8k](/login?return_to=%2FOpenAPITools%2Fopenapi-generator)
--   [Star 23.1k](/login?return_to=%2FOpenAPITools%2Fopenapi-generator)
-    
+- [Notifications](/login?return_to=%2FOpenAPITools%2Fopenapi-generator) You must be signed in to change notification settings
+- [Fork 6.8k](/login?return_to=%2FOpenAPITools%2Fopenapi-generator)
+- [Star 23.1k](/login?return_to=%2FOpenAPITools%2Fopenapi-generator)
 
 OpenAPI Generator allows generation of API client libraries (SDK generation), server stubs, documentation and configuration automatically given an OpenAPI Spec (v2, v3)
 
@@ -238,31 +246,29 @@ OpenAPI Generator allows generation of API client libraries (SDK generation), se
 
 [Notifications](/login?return_to=%2FOpenAPITools%2Fopenapi-generator) You must be signed in to change notification settings
 
--   [Code](/OpenAPITools/openapi-generator)
--   [Issues 4.7k](/OpenAPITools/openapi-generator/issues)
--   [Pull requests 529](/OpenAPITools/openapi-generator/pulls)
--   [Actions](/OpenAPITools/openapi-generator/actions)
--   [Projects 0](/OpenAPITools/openapi-generator/projects)
--   [Wiki](/OpenAPITools/openapi-generator/wiki)
--   [Security](/OpenAPITools/openapi-generator/security)
--   [Insights](/OpenAPITools/openapi-generator/pulse)
+- [Code](/OpenAPITools/openapi-generator)
+- [Issues 4.7k](/OpenAPITools/openapi-generator/issues)
+- [Pull requests 529](/OpenAPITools/openapi-generator/pulls)
+- [Actions](/OpenAPITools/openapi-generator/actions)
+- [Projects 0](/OpenAPITools/openapi-generator/projects)
+- [Wiki](/OpenAPITools/openapi-generator/wiki)
+- [Security](/OpenAPITools/openapi-generator/security)
+- [Insights](/OpenAPITools/openapi-generator/pulse)
 
 Additional navigation options
 
--   [Code](/OpenAPITools/openapi-generator)
--   [Issues](/OpenAPITools/openapi-generator/issues)
--   [Pull requests](/OpenAPITools/openapi-generator/pulls)
--   [Actions](/OpenAPITools/openapi-generator/actions)
--   [Projects](/OpenAPITools/openapi-generator/projects)
--   [Wiki](/OpenAPITools/openapi-generator/wiki)
--   [Security](/OpenAPITools/openapi-generator/security)
--   [Insights](/OpenAPITools/openapi-generator/pulse)
+- [Code](/OpenAPITools/openapi-generator)
+- [Issues](/OpenAPITools/openapi-generator/issues)
+- [Pull requests](/OpenAPITools/openapi-generator/pulls)
+- [Actions](/OpenAPITools/openapi-generator/actions)
+- [Projects](/OpenAPITools/openapi-generator/projects)
+- [Wiki](/OpenAPITools/openapi-generator/wiki)
+- [Security](/OpenAPITools/openapi-generator/security)
+- [Insights](/OpenAPITools/openapi-generator/pulse)
 
 # OpenAPITools/openapi-generator
 
-  
-
- master
+master
 
 [Branches](/OpenAPITools/openapi-generator/branches)[Tags](/OpenAPITools/openapi-generator/tags)
 
@@ -378,9 +384,9 @@ Last commit date
 
 [.travis.yml](/OpenAPITools/openapi-generator/blob/master/.travis.yml ".travis.yml")
 
-[CODE\_OF\_CONDUCT.md](/OpenAPITools/openapi-generator/blob/master/CODE_OF_CONDUCT.md "CODE_OF_CONDUCT.md")
+[CODE_OF_CONDUCT.md](/OpenAPITools/openapi-generator/blob/master/CODE_OF_CONDUCT.md "CODE_OF_CONDUCT.md")
 
-[CODE\_OF\_CONDUCT.md](/OpenAPITools/openapi-generator/blob/master/CODE_OF_CONDUCT.md "CODE_OF_CONDUCT.md")
+[CODE_OF_CONDUCT.md](/OpenAPITools/openapi-generator/blob/master/CODE_OF_CONDUCT.md "CODE_OF_CONDUCT.md")
 
 [CONTRIBUTING.md](/OpenAPITools/openapi-generator/blob/master/CONTRIBUTING.md "CONTRIBUTING.md")
 
@@ -426,9 +432,9 @@ Last commit date
 
 [flake.nix](/OpenAPITools/openapi-generator/blob/master/flake.nix "flake.nix")
 
-[google\_checkstyle.xml](/OpenAPITools/openapi-generator/blob/master/google_checkstyle.xml "google_checkstyle.xml")
+[google_checkstyle.xml](/OpenAPITools/openapi-generator/blob/master/google_checkstyle.xml "google_checkstyle.xml")
 
-[google\_checkstyle.xml](/OpenAPITools/openapi-generator/blob/master/google_checkstyle.xml "google_checkstyle.xml")
+[google_checkstyle.xml](/OpenAPITools/openapi-generator/blob/master/google_checkstyle.xml "google_checkstyle.xml")
 
 [intellij-codestyle.xml](/OpenAPITools/openapi-generator/blob/master/intellij-codestyle.xml "intellij-codestyle.xml")
 
@@ -478,9 +484,9 @@ View all files
 
 ## Repository files navigation
 
--   [README](#)
--   [Code of conduct](#)
--   [Apache-2.0 license](#)
+- [README](#)
+- [Code of conduct](#)
+- [Apache-2.0 license](#)
 
 # OpenAPI Generator
 
@@ -552,32 +558,32 @@ Languages/Frameworks
 
 [](#table-of-contents)
 
--   [OpenAPI Generator](#openapi-generator)
--   [Overview](#overview)
--   [Table of Contents](#table-of-contents)
--   [1 - Installation](#1---installation)
-    -   [1.1 - Compatibility](#11---compatibility)
-    -   [1.2 - Artifacts on Maven Central](#12---artifacts-on-maven-central)
-    -   [1.3 - Download JAR](#13---download-jar)
-    -   [1.4 - Build Projects](#14---build-projects)
-    -   [1.5 - Homebrew](#15---homebrew)
-    -   [1.6 - Docker](#16---docker)
-    -   [1.7 - NPM](#17---npm)
-    -   [1.8 - pip](#18---pip)
--   [2 - Getting Started](#2---getting-started)
--   [3 - Usage](#3---usage)
-    -   [3.1 - Customization](#31---customization)
-    -   [3.2 - Workflow Integration](#32---workflow-integration-maven-gradle-github-cicd)
-    -   [3.3 - Online Generators](#33---online-openapi-generator)
-    -   [3.4 - License Information on Generated Code](#34---license-information-on-generated-code)
-    -   [3.5 - IDE Integration](#35---ide-integration)
--   [4 - Companies/Projects using OpenAPI Generator](#4---companiesprojects-using-openapi-generator)
--   [5 - Presentations/Videos/Tutorials/Books](#5---presentationsvideostutorialsbooks)
--   [6 - About Us](#6---about-us)
-    -   [6.1 - OpenAPI Generator Core Team](#61---openapi-generator-core-team)
-    -   [6.2 - OpenAPI Generator Technical Committee](#62---openapi-generator-technical-committee)
-    -   [6.3 - History of OpenAPI Generator](#63---history-of-openapi-generator)
--   [7 - License](#7---license)
+- [OpenAPI Generator](#openapi-generator)
+- [Overview](#overview)
+- [Table of Contents](#table-of-contents)
+- [1 - Installation](#1---installation)
+  - [1.1 - Compatibility](#11---compatibility)
+  - [1.2 - Artifacts on Maven Central](#12---artifacts-on-maven-central)
+  - [1.3 - Download JAR](#13---download-jar)
+  - [1.4 - Build Projects](#14---build-projects)
+  - [1.5 - Homebrew](#15---homebrew)
+  - [1.6 - Docker](#16---docker)
+  - [1.7 - NPM](#17---npm)
+  - [1.8 - pip](#18---pip)
+- [2 - Getting Started](#2---getting-started)
+- [3 - Usage](#3---usage)
+  - [3.1 - Customization](#31---customization)
+  - [3.2 - Workflow Integration](#32---workflow-integration-maven-gradle-github-cicd)
+  - [3.3 - Online Generators](#33---online-openapi-generator)
+  - [3.4 - License Information on Generated Code](#34---license-information-on-generated-code)
+  - [3.5 - IDE Integration](#35---ide-integration)
+- [4 - Companies/Projects using OpenAPI Generator](#4---companiesprojects-using-openapi-generator)
+- [5 - Presentations/Videos/Tutorials/Books](#5---presentationsvideostutorialsbooks)
+- [6 - About Us](#6---about-us)
+  - [6.1 - OpenAPI Generator Core Team](#61---openapi-generator-core-team)
+  - [6.2 - OpenAPI Generator Technical Committee](#62---openapi-generator-technical-committee)
+  - [6.3 - History of OpenAPI Generator](#63---history-of-openapi-generator)
+- [7 - License](#7---license)
 
 ## [1 - Installation](#table-of-contents)
 
@@ -642,9 +648,9 @@ You can find our released artifacts on maven central:
 **Core:**
 
 <dependency\>
-    <groupId\>org.openapitools</groupId\>
-    <artifactId\>openapi-generator</artifactId\>
-    <version\>${openapi-generator-version}</version\>
+<groupId\>org.openapitools</groupId\>
+<artifactId\>openapi-generator</artifactId\>
+<version\>${openapi-generator-version}</version\>
 </dependency\>
 
 See the different versions of the [openapi-generator](https://search.maven.org/artifact/org.openapitools/openapi-generator) artifact available on maven central.
@@ -652,9 +658,9 @@ See the different versions of the [openapi-generator](https://search.maven.org/a
 **Cli:**
 
 <dependency\>
-    <groupId\>org.openapitools</groupId\>
-    <artifactId\>openapi-generator-cli</artifactId\>
-    <version\>${openapi-generator-version}</version\>
+<groupId\>org.openapitools</groupId\>
+<artifactId\>openapi-generator-cli</artifactId\>
+<version\>${openapi-generator-version}</version\>
 </dependency\>
 
 See the different versions of the [openapi-generator-cli](https://search.maven.org/artifact/org.openapitools/openapi-generator-cli) artifact available on maven central.
@@ -662,24 +668,24 @@ See the different versions of the [openapi-generator-cli](https://search.maven.o
 **Maven plugin:**
 
 <dependency\>
-    <groupId\>org.openapitools</groupId\>
-    <artifactId\>openapi-generator-maven-plugin</artifactId\>
-    <version\>${openapi-generator-version}</version\>
+<groupId\>org.openapitools</groupId\>
+<artifactId\>openapi-generator-maven-plugin</artifactId\>
+<version\>${openapi-generator-version}</version\>
 </dependency\>
 
--   See the different versions of the [openapi-generator-maven-plugin](https://search.maven.org/artifact/org.openapitools/openapi-generator-maven-plugin) artifact available on maven central.
--   [Readme](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md)
+- See the different versions of the [openapi-generator-maven-plugin](https://search.maven.org/artifact/org.openapitools/openapi-generator-maven-plugin) artifact available on maven central.
+- [Readme](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md)
 
 **Gradle plugin:**
 
 <dependency\>
-    <groupId\>org.openapitools</groupId\>
-    <artifactId\>openapi-generator-gradle-plugin</artifactId\>
-    <version\>${openapi-generator-version}</version\>
+<groupId\>org.openapitools</groupId\>
+<artifactId\>openapi-generator-gradle-plugin</artifactId\>
+<version\>${openapi-generator-version}</version\>
 </dependency\>
 
--   See the different versions of the [openapi-generator-gradle-plugin](https://search.maven.org/artifact/org.openapitools/openapi-generator-gradle-plugin) artifact available on maven central.
--   [Readme](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-gradle-plugin/README.adoc)
+- See the different versions of the [openapi-generator-gradle-plugin](https://search.maven.org/artifact/org.openapitools/openapi-generator-gradle-plugin) artifact available on maven central.
+- [Readme](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-gradle-plugin/README.adoc)
 
 ### [1.3 - Download JAR](#table-of-contents)
 
@@ -703,7 +709,7 @@ After downloading the JAR, run `java -jar openapi-generator-cli.jar help` to sho
 
 For Mac users, please make sure Java 11 is installed (Tips: run `java -version` to check the version), and export `JAVA_HOME` in order to use the supported Java version:
 
-export JAVA\_HOME=\`/usr/libexec/java\_home -v 1.11\`
+export JAVA_HOME=\`/usr/libexec/java_home -v 1.11\`
 export PATH=${JAVA\_HOME}/bin:$PATH
 
 ### Launcher Script
@@ -739,15 +745,15 @@ OPENAPI_GENERATOR_VERSION=4.1.0 openapi-generator-cli version
 # Execute version 4.1.0-SNAPSHOT for the current invocation
 OPENAPI_GENERATOR_VERSION=4.1.0-SNAPSHOT openapi-generator-cli version
 
-# Execute version 4.0.3 for every invocation in the current shell session
-export OPENAPI_GENERATOR_VERSION=4.0.3
-openapi-generator-cli version # is 4.0.3
-openapi-generator-cli version # is also 4.0.3
+# Execute version 4.0.4 for every invocation in the current shell session
+export OPENAPI_GENERATOR_VERSION=4.0.4
+openapi-generator-cli version # is 4.0.4
+openapi-generator-cli version # is also 4.0.4
 
 # To "install" a specific version, set the variable in .bashrc/.bash_profile
-echo "export OPENAPI_GENERATOR_VERSION=4.0.3" >> ~/.bashrc
+echo "export OPENAPI_GENERATOR_VERSION=4.0.4" >> ~/.bashrc
 source ~/.bashrc
-openapi-generator-cli version # is always 4.0.3, unless any of the above overrides are done ad hoc
+openapi-generator-cli version # is always 4.0.4, unless any of the above overrides are done ad hoc
 ```
 
 ### [1.4 - Build Projects](#table-of-contents)
@@ -756,15 +762,13 @@ openapi-generator-cli version # is always 4.0.3, unless any of the above overrid
 
 To build from source, you need the following installed and available in your `$PATH:`
 
--   [Java 11](https://adoptium.net/)
-    
--   [Apache Maven 3.8.8 or greater](https://maven.apache.org/) (optional)
-    
+- [Java 11](https://adoptium.net/)
+- [Apache Maven 3.8.8 or greater](https://maven.apache.org/) (optional)
 
 After cloning the project, you can build it from source using [maven wrapper](https://maven.apache.org/wrapper/):
 
--   Linux: `./mvnw clean install`
--   Windows: `mvnw.cmd clean install`
+- Linux: `./mvnw clean install`
+- Windows: `mvnw.cmd clean install`
 
 #### Nix users
 
@@ -784,8 +788,8 @@ and have `java` and `mvn` set up with correct versions each time you enter proje
 
 The default build contains minimal static analysis (via CheckStyle). To run your build with PMD and Spotbugs, use the `static-analysis` profile:
 
--   Linux: `./mvnw -Pstatic-analysis clean install`
--   Windows: `mvnw.cmd -Pstatic-analysis clean install`
+- Linux: `./mvnw -Pstatic-analysis clean install`
+- Windows: `mvnw.cmd -Pstatic-analysis clean install`
 
 ### [1.5 - Homebrew](#table-of-contents)
 
@@ -803,7 +807,7 @@ To install OpenJDK (pre-requisites), please run
 
 brew tap AdoptOpenJDK/openjdk
 brew install --cask adoptopenjdk11
-export JAVA\_HOME=\`/usr/libexec/java\_home -v 1.11\`
+export JAVA_HOME=\`/usr/libexec/java_home -v 1.11\`
 
 or download installer via [https://adoptium.net/](https://adoptium.net/)
 
@@ -819,8 +823,8 @@ brew install maven
 
 [](#public-pre-built-docker-images)
 
--   [https://hub.docker.com/r/openapitools/openapi-generator-cli/](https://hub.docker.com/r/openapitools/openapi-generator-cli/) (official CLI)
--   [https://hub.docker.com/r/openapitools/openapi-generator-online/](https://hub.docker.com/r/openapitools/openapi-generator-online/) (official web service)
+- [https://hub.docker.com/r/openapitools/openapi-generator-cli/](https://hub.docker.com/r/openapitools/openapi-generator-cli/) (official CLI)
+- [https://hub.docker.com/r/openapitools/openapi-generator-online/](https://hub.docker.com/r/openapitools/openapi-generator-online/) (official web service)
 
 #### OpenAPI Generator CLI Docker Image
 
@@ -833,9 +837,9 @@ To generate code with this image, you'll need to mount a local location as a vol
 Example:
 
 docker run --rm -v "${PWD}:/local" openapitools/openapi-generator-cli generate \\
-    -i https://raw.githubusercontent.com/openapitools/openapi-generator/master/modules/openapi-generator/src/test/resources/3\_0/petstore.yaml \\
-    -g go \\
-    -o /local/out/go
+-i https://raw.githubusercontent.com/openapitools/openapi-generator/master/modules/openapi-generator/src/test/resources/3\_0/petstore.yaml \\
+-g go \\
+-o /local/out/go
 
 The generated code will be located under `./out/go` in the current directory.
 
@@ -848,15 +852,19 @@ The openapi-generator-online image can act as a self-hosted web application and 
 Example usage:
 
 # Start container at port 8888 and save the container id
+
 \> CID=$(docker run -d -p 8888:8080 openapitools/openapi-generator-online)
 
 # allow for startup
+
 \> sleep 10
 
 # Get the IP of the running container (optional)
-GEN\_IP=$(docker inspect --format '{{.NetworkSettings.IPAddress}}'  $CID)
+
+GEN_IP=$(docker inspect --format '{{.NetworkSettings.IPAddress}}' $CID)
 
 # Execute an HTTP request to generate a Ruby client
+
 \> curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' \\
 -d '{"openAPIUrl": "https://raw.githubusercontent.com/openapitools/openapi-generator/master/modules/openapi-generator/src/test/resources/3\_0/petstore.yaml"}' \\
 'http://localhost:8888/api/gen/clients/ruby'
@@ -864,12 +872,15 @@ GEN\_IP=$(docker inspect --format '{{.NetworkSettings.IPAddress}}'  $CID)
 {"code":"c2d483.3.4672-40e9-91df-b9ffd18d22b8","link":"http://localhost:8888/api/gen/download/c2d483.3.4672-40e9-91df-b9ffd18d22b8"}
 
 # Download the generated zip file
+
 \> wget http://localhost:8888/api/gen/download/c2d483.3.4672-40e9-91df-b9ffd18d22b8
 
 # Unzip the file
+
 \> unzip c2d483.3.4672-40e9-91df-b9ffd18d22b8
 
 # Shutdown the openapi generator image
+
 \> docker stop $CID && docker rm $CID
 
 #### Development in docker
@@ -890,8 +901,8 @@ Once built, `run-in-docker.sh` will act as an executable for openapi-generator-c
 
 ./run-in-docker.sh help # Executes 'help' command for openapi-generator-cli
 ./run-in-docker.sh list # Executes 'list' command for openapi-generator-cli
-./run-in-docker.sh generate -i modules/openapi-generator/src/test/resources/3\_0/petstore.yaml \\
-    -g go -o /gen/out/go-petstore -p packageName=petstore # generates go client, outputs locally to ./out/go-petstore
+./run-in-docker.sh generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml \\
+-g go -o /gen/out/go-petstore -p packageName=petstore # generates go client, outputs locally to ./out/go-petstore
 
 ##### Troubleshooting
 
@@ -975,9 +986,9 @@ git clone https://github.com/openapitools/openapi-generator
 cd openapi-generator
 ./mvnw clean package
 java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \\
-   -i https://raw.githubusercontent.com/openapitools/openapi-generator/master/modules/openapi-generator/src/test/resources/3\_0/petstore.yaml \\
-   -g php \\
-   -o /var/tmp/php\_api\_client
+-i https://raw.githubusercontent.com/openapitools/openapi-generator/master/modules/openapi-generator/src/test/resources/3\_0/petstore.yaml \\
+-g php \\
+-o /var/tmp/php_api_client
 
 (if you're on Windows, replace the last command with `java -jar modules\openapi-generator-cli\target\openapi-generator-cli.jar generate -i https://raw.githubusercontent.com/openapitools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g php -o c:\temp\php_api_client`)
 
@@ -1004,11 +1015,11 @@ You can build a client against the [Petstore API](https://raw.githubusercontent.
 This script uses the default library, which is `okhttp-gson`. It will run the generator with this command:
 
 java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \\
-  -i https://raw.githubusercontent.com/openapitools/openapi-generator/master/modules/openapi-generator/src/test/resources/3\_0/petstore.yaml \\
-  -g java \\
-  -t modules/openapi-generator/src/main/resources/Java \\
-  --additional-properties artifactId=petstore-okhttp-gson,hideGenerationTimestamp=true \\
-  -o samples/client/petstore/java/okhttp-gson
+-i https://raw.githubusercontent.com/openapitools/openapi-generator/master/modules/openapi-generator/src/test/resources/3\_0/petstore.yaml \\
+-g java \\
+-t modules/openapi-generator/src/main/resources/Java \\
+--additional-properties artifactId=petstore-okhttp-gson,hideGenerationTimestamp=true \\
+-o samples/client/petstore/java/okhttp-gson
 
 with a number of options. [The java options are documented here.](/OpenAPITools/openapi-generator/blob/master/docs/generators/java.md)
 
@@ -1090,8 +1101,8 @@ Please refer to [integration.md](/OpenAPITools/openapi-generator/blob/master/doc
 
 Here are the public online services:
 
--   latest stable version: [https://api.openapi-generator.tech](https://api.openapi-generator.tech)
--   latest master: [https://api-latest-master.openapi-generator.tech](https://api-latest-master.openapi-generator.tech) (updated with latest master every hour)
+- latest stable version: [https://api.openapi-generator.tech](https://api.openapi-generator.tech)
+- latest master: [https://api-latest-master.openapi-generator.tech](https://api-latest-master.openapi-generator.tech) (updated with latest master every hour)
 
 The server is sponsored by [Linode](https://www.linode.com/) [![Linode Logo](https://camo.githubusercontent.com/8b228e16e47d936acebdfbf7ab04fa48d5ac084e5e8869020354b7386ad729c8/68747470733a2f2f7777772e6c696e6f64652e636f6d2f6d656469612f696d616765732f6c6f676f732f7374616e646172642f6c696768742f6c696e6f64652d6c6f676f5f7374616e646172645f6c696768745f736d616c6c2e706e67)](https://www.linode.com/)
 
@@ -1105,8 +1116,8 @@ Please refer to [online.md](/OpenAPITools/openapi-generator/blob/master/docs/onl
 
 The OpenAPI Generator project is intended as a benefit for users of the Open API Specification. The project itself has the [License](#7---license) as specified. In addition, please understand the following points:
 
--   The templates included with this project are subject to the [License](#7---license).
--   Generated code is intentionally *not* subject to the parent project license
+- The templates included with this project are subject to the [License](#7---license).
+- Generated code is intentionally _not_ subject to the parent project license
 
 When code is generated from this project, it shall be considered **AS IS** and owned by the user of the software. There are no warranties--expressed or implied--for generated code. You can do what you wish with it, and once generated, the code is your responsibility and subject to the licensing terms that you deem appropriate.
 
@@ -1116,12 +1127,12 @@ When code is generated from this project, it shall be considered **AS IS** and o
 
 Here is a list of community-contributed IDE plug-ins that integrate with OpenAPI Generator:
 
--   Eclipse: [Codewind OpenAPI Tools for Eclipse](https://www.eclipse.org/codewind/open-api-tools-for-eclipse.html) by [IBM](https://www.ibm.com)
--   IntelliJ IDEA: [OpenAPI Generator](https://plugins.jetbrains.com/plugin/8433-openapi-generator) by [Jim Schubert](https://jimschubert.us/#/)
--   IntelliJ IDEA: [Senya Editor](https://plugins.jetbrains.com/plugin/10690-senya-editor) by [senya.io](https://senya.io)
--   [RepreZen API Studio](https://www.reprezen.com/)
--   Visual Studio: [REST API Client Code Generator](https://marketplace.visualstudio.com/items?itemName=ChristianResmaHelle.ApiClientCodeGenerator) by [Christian Resma Helle](https://christian-helle.blogspot.com/)
--   Visual Studio Code: [Codewind OpenAPI Tools](https://marketplace.visualstudio.com/items?itemName=IBM.codewind-openapi-tools) by [IBM](https://marketplace.visualstudio.com/publishers/IBM)
+- Eclipse: [Codewind OpenAPI Tools for Eclipse](https://www.eclipse.org/codewind/open-api-tools-for-eclipse.html) by [IBM](https://www.ibm.com)
+- IntelliJ IDEA: [OpenAPI Generator](https://plugins.jetbrains.com/plugin/8433-openapi-generator) by [Jim Schubert](https://jimschubert.us/#/)
+- IntelliJ IDEA: [Senya Editor](https://plugins.jetbrains.com/plugin/10690-senya-editor) by [senya.io](https://senya.io)
+- [RepreZen API Studio](https://www.reprezen.com/)
+- Visual Studio: [REST API Client Code Generator](https://marketplace.visualstudio.com/items?itemName=ChristianResmaHelle.ApiClientCodeGenerator) by [Christian Resma Helle](https://christian-helle.blogspot.com/)
+- Visual Studio Code: [Codewind OpenAPI Tools](https://marketplace.visualstudio.com/items?itemName=IBM.codewind-openapi-tools) by [IBM](https://marketplace.visualstudio.com/publishers/IBM)
 
 ## [4 - Companies/Projects using OpenAPI Generator](#table-of-contents)
 
@@ -1129,356 +1140,356 @@ Here is a list of community-contributed IDE plug-ins that integrate with OpenAPI
 
 Here are some companies/projects (alphabetical order) using OpenAPI Generator in production. To add your company/project to the list, please visit [README.md](/OpenAPITools/openapi-generator/blob/master/README.md) and click on the icon to edit the page.
 
--   [Aalborg University](https://www.aau.dk)
--   [act coding](https://github.com/actcoding)
--   [Adaptant Solutions AG](https://www.adaptant.io/)
--   [adesso SE](https://www.adesso.de/)
--   [adorsys GmbH & Co.KG](https://adorsys.com/)
--   [Adyen](https://www.adyen.com/)
--   [Agoda](https://www.agoda.com/)
--   [Airthings](https://www.airthings.com/)
--   [Aleri Solutions Gmbh](https://www.aleri.de/)
--   [Allianz](https://www.allianz.com)
--   [Angular.Schule](https://angular.schule/)
--   [Aqovia](https://aqovia.com/)
--   [Australia and New Zealand Banking Group (ANZ)](http://www.anz.com/)
--   [Arduino](https://www.arduino.cc/)
--   [ASKUL](https://www.askul.co.jp)
--   [Amazon Web Services (AWS)](https://aws.amazon.com/)
--   [b<>com](https://b-com.com/en)
--   [百度营销](https://e.baidu.com)
--   [Bandwidth](https://dev.bandwidth.com)
--   [Banzai Cloud](https://banzaicloud.com)
--   [BIMData.io](https://bimdata.io)
--   [Bithost GmbH](https://www.bithost.ch)
--   [Bosch Connected Industry](https://www.bosch-connected-industry.com)
--   [Boxever](https://www.boxever.com/)
--   [Brevy](https://www.brevy.com)
--   [Bunker Holding Group](https://www.bunker-holding.com/)
--   [California State University, Northridge](https://www.csun.edu)
--   [CAM](https://www.cam-inc.co.jp/)
--   [Camptocamp](https://www.camptocamp.com/en)
--   [Carlsberg Group](https://www.carlsberggroup.com/)
--   [CERN](https://home.cern/)
--   [Christopher Queen Consulting](https://www.christopherqueenconsulting.com/)
--   [Cisco](https://www.cisco.com/)
--   [codecentric AG](https://www.codecentric.de/)
--   [CoinAPI](https://www.coinapi.io/)
--   [Commencis](https://www.commencis.com/)
--   [ConfigCat](https://configcat.com/)
--   [cronn GmbH](https://www.cronn.de/)
--   [Crossover Health](https://crossoverhealth.com/)
--   [Cupix](https://www.cupix.com/)
--   [Datadog](https://www.datadoghq.com)
--   [DB Systel](https://www.dbsystel.de)
--   [Deeporute.ai](https://www.deeproute.ai/)
--   [Devsupply](https://www.devsupply.com/)
--   [dmTECH GmbH](https://www.dmTECH.de)
--   [DocSpring](https://docspring.com/)
--   [dwango](https://dwango.co.jp/)
--   [Edge Impulse](https://www.edgeimpulse.com/)
--   [Element AI](https://www.elementai.com/)
--   [Embotics](https://www.embotics.com/)
--   [emineo](https://www.emineo.ch)
--   [fastly](https://www.fastly.com/)
--   [Fenergo](https://www.fenergo.com/)
--   [freee](https://corp.freee.co.jp/en/)
--   [FreshCells](https://www.freshcells.de/)
--   [Fuse](https://www.fuse.no/)
--   [Gantner](https://www.gantner.com)
--   [GenFlow](https://github.com/RepreZen/GenFlow)
--   [GetYourGuide](https://www.getyourguide.com/)
--   [Glovo](https://glovoapp.com/)
--   [GMO Pepabo](https://pepabo.com/en/)
--   [GoDaddy](https://godaddy.com)
--   [Gumtree](https://gumtree.com)
--   [Here](https://developer.here.com/)
--   [IBM](https://www.ibm.com/)
--   [Instana](https://www.instana.com)
--   [Interxion](https://www.interxion.com)
--   [Inquisico](https://inquisico.com)
--   [JustStar](https://www.juststarinfo.com)
--   [k6.io](https://k6.io/)
--   [Klarna](https://www.klarna.com/)
--   [Kronsoft Development](https://www.kronsoft.ro/home/)
--   [Kubernetes](https://kubernetes.io)
--   [Landeshauptstadt München - it@M](https://muenchen.digital/it-at-m/)
--   [Linode](https://www.linode.com/)
--   [Logicdrop](https://www.logicdrop.com)
--   [Lumeris](https://www.lumeris.com)
--   [LVM Versicherungen](https://www.lvm.de)
--   [MailSlurp](https://www.mailslurp.com)
--   [Manticore Search](https://manticoresearch.com)
--   [Mastercard](https://developers.mastercard.com)
--   [Médiavision](https://www.mediavision.fr/)
--   [Metaswitch](https://www.metaswitch.com/)
--   [MoonVision](https://www.moonvision.io/)
--   [Myworkout](https://myworkout.com)
--   [NamSor](https://www.namsor.com/)
--   [Neverfail](https://www.neverfail.com/)
--   [NeuerEnergy](https://neuerenergy.com)
--   [Nokia](https://www.nokia.com/)
--   [OneSignal](https://www.onesignal.com/)
--   [Options Clearing Corporation (OCC)](https://www.theocc.com/)
--   [Openet](https://www.openet.com/)
--   [openVALIDATION](https://openvalidation.io/)
--   [Oracle](https://www.oracle.com/)
--   [Paxos](https://www.paxos.com)
--   [Plaid](https://plaid.com)
--   [PLAID, Inc.](https://plaid.co.jp/)
--   [Pinterest](https://www.pinterest.com)
--   [Ponicode](https://ponicode.dev/)
--   [Pricefx](https://www.pricefx.com/)
--   [PrintNanny](https://www.print-nanny.com/)
--   [Prometheus/Alertmanager](https://github.com/prometheus/alertmanager)
--   [Qavar](https://www.qavar.com)
--   [QEDIT](https://qed-it.com)
--   [Qovery](https://qovery.com)
--   [Qulix Systems](https://www.qulix.com)
--   [Raksul](https://corp.raksul.com)
--   [Raiffeisen Schweiz Genossenschaft](https://www.raiffeisen.ch)
--   [RedHat](https://www.redhat.com)
--   [RepreZen API Studio](https://www.reprezen.com/swagger-openapi-code-generation-api-first-microservices-enterprise-development)
--   [REST United](https://restunited.com)
--   [Robocorp](https://www.robocorp.com)
--   [Robotinfra](https://www.robotinfra.com)
--   [SearchApi](https://www.searchapi.io/)
--   [SmartHR](https://smarthr.co.jp/)
--   [Sony Interactive Entertainment](https://www.sie.com/en/index.html)
--   [Splitit](https://www.splitit.com/)
--   [Stingray](http://www.stingray.com)
--   [Suva](https://www.suva.ch/)
--   [Svix](https://www.svix.com/)
--   [Telstra](https://dev.telstra.com)
--   [Tencent](https://www.tencent.com)
--   [The University of Aizu](https://www.u-aizu.ac.jp/en/)
--   [TINQIN](https://www.tinqin.com/)
--   [Translucent ApS](https://www.translucent.dk)
--   [TravelTime platform](https://www.traveltimeplatform.com/)
--   [TribalScale](https://www.tribalscale.com)
--   [Trifork](https://trifork.com)
--   [TUI InfoTec GmbH](http://www.tui-infotec.com/)
--   [Twilio](https://www.twilio.com/)
--   [Twitter](https://twitter.com)
--   [unblu inc.](https://www.unblu.com/)
--   [Veamly](https://www.veamly.com/)
--   [VMWare](https://www.vmware.com/)
--   [wbt-solutions](https://www.wbt-solutions.de/)
--   [Woleet](https://www.woleet.io/)
--   [WSO2](https://wso2.com/)
--   [Vouchery.io](https://vouchery.io)
--   [Xero](https://www.xero.com/)
--   [Yahoo Japan](https://www.yahoo.co.jp/)
--   [viadee](https://www.viadee.de/)
--   [Vonage](https://vonage.com)
--   [YITU Technology](https://www.yitutech.com/)
--   [Yelp](https://www.yelp.com/)
--   [Zalando](https://www.zalando.com)
--   [3DS Outscale](https://www.outscale.com/)
+- [Aalborg University](https://www.aau.dk)
+- [act coding](https://github.com/actcoding)
+- [Adaptant Solutions AG](https://www.adaptant.io/)
+- [adesso SE](https://www.adesso.de/)
+- [adorsys GmbH & Co.KG](https://adorsys.com/)
+- [Adyen](https://www.adyen.com/)
+- [Agoda](https://www.agoda.com/)
+- [Airthings](https://www.airthings.com/)
+- [Aleri Solutions Gmbh](https://www.aleri.de/)
+- [Allianz](https://www.allianz.com)
+- [Angular.Schule](https://angular.schule/)
+- [Aqovia](https://aqovia.com/)
+- [Australia and New Zealand Banking Group (ANZ)](http://www.anz.com/)
+- [Arduino](https://www.arduino.cc/)
+- [ASKUL](https://www.askul.co.jp)
+- [Amazon Web Services (AWS)](https://aws.amazon.com/)
+- [b<>com](https://b-com.com/en)
+- [百度营销](https://e.baidu.com)
+- [Bandwidth](https://dev.bandwidth.com)
+- [Banzai Cloud](https://banzaicloud.com)
+- [BIMData.io](https://bimdata.io)
+- [Bithost GmbH](https://www.bithost.ch)
+- [Bosch Connected Industry](https://www.bosch-connected-industry.com)
+- [Boxever](https://www.boxever.com/)
+- [Brevy](https://www.brevy.com)
+- [Bunker Holding Group](https://www.bunker-holding.com/)
+- [California State University, Northridge](https://www.csun.edu)
+- [CAM](https://www.cam-inc.co.jp/)
+- [Camptocamp](https://www.camptocamp.com/en)
+- [Carlsberg Group](https://www.carlsberggroup.com/)
+- [CERN](https://home.cern/)
+- [Christopher Queen Consulting](https://www.christopherqueenconsulting.com/)
+- [Cisco](https://www.cisco.com/)
+- [codecentric AG](https://www.codecentric.de/)
+- [CoinAPI](https://www.coinapi.io/)
+- [Commencis](https://www.commencis.com/)
+- [ConfigCat](https://configcat.com/)
+- [cronn GmbH](https://www.cronn.de/)
+- [Crossover Health](https://crossoverhealth.com/)
+- [Cupix](https://www.cupix.com/)
+- [Datadog](https://www.datadoghq.com)
+- [DB Systel](https://www.dbsystel.de)
+- [Deeporute.ai](https://www.deeproute.ai/)
+- [Devsupply](https://www.devsupply.com/)
+- [dmTECH GmbH](https://www.dmTECH.de)
+- [DocSpring](https://docspring.com/)
+- [dwango](https://dwango.co.jp/)
+- [Edge Impulse](https://www.edgeimpulse.com/)
+- [Element AI](https://www.elementai.com/)
+- [Embotics](https://www.embotics.com/)
+- [emineo](https://www.emineo.ch)
+- [fastly](https://www.fastly.com/)
+- [Fenergo](https://www.fenergo.com/)
+- [freee](https://corp.freee.co.jp/en/)
+- [FreshCells](https://www.freshcells.de/)
+- [Fuse](https://www.fuse.no/)
+- [Gantner](https://www.gantner.com)
+- [GenFlow](https://github.com/RepreZen/GenFlow)
+- [GetYourGuide](https://www.getyourguide.com/)
+- [Glovo](https://glovoapp.com/)
+- [GMO Pepabo](https://pepabo.com/en/)
+- [GoDaddy](https://godaddy.com)
+- [Gumtree](https://gumtree.com)
+- [Here](https://developer.here.com/)
+- [IBM](https://www.ibm.com/)
+- [Instana](https://www.instana.com)
+- [Interxion](https://www.interxion.com)
+- [Inquisico](https://inquisico.com)
+- [JustStar](https://www.juststarinfo.com)
+- [k6.io](https://k6.io/)
+- [Klarna](https://www.klarna.com/)
+- [Kronsoft Development](https://www.kronsoft.ro/home/)
+- [Kubernetes](https://kubernetes.io)
+- [Landeshauptstadt München - it@M](https://muenchen.digital/it-at-m/)
+- [Linode](https://www.linode.com/)
+- [Logicdrop](https://www.logicdrop.com)
+- [Lumeris](https://www.lumeris.com)
+- [LVM Versicherungen](https://www.lvm.de)
+- [MailSlurp](https://www.mailslurp.com)
+- [Manticore Search](https://manticoresearch.com)
+- [Mastercard](https://developers.mastercard.com)
+- [Médiavision](https://www.mediavision.fr/)
+- [Metaswitch](https://www.metaswitch.com/)
+- [MoonVision](https://www.moonvision.io/)
+- [Myworkout](https://myworkout.com)
+- [NamSor](https://www.namsor.com/)
+- [Neverfail](https://www.neverfail.com/)
+- [NeuerEnergy](https://neuerenergy.com)
+- [Nokia](https://www.nokia.com/)
+- [OneSignal](https://www.onesignal.com/)
+- [Options Clearing Corporation (OCC)](https://www.theocc.com/)
+- [Openet](https://www.openet.com/)
+- [openVALIDATION](https://openvalidation.io/)
+- [Oracle](https://www.oracle.com/)
+- [Paxos](https://www.paxos.com)
+- [Plaid](https://plaid.com)
+- [PLAID, Inc.](https://plaid.co.jp/)
+- [Pinterest](https://www.pinterest.com)
+- [Ponicode](https://ponicode.dev/)
+- [Pricefx](https://www.pricefx.com/)
+- [PrintNanny](https://www.print-nanny.com/)
+- [Prometheus/Alertmanager](https://github.com/prometheus/alertmanager)
+- [Qavar](https://www.qavar.com)
+- [QEDIT](https://qed-it.com)
+- [Qovery](https://qovery.com)
+- [Qulix Systems](https://www.qulix.com)
+- [Raksul](https://corp.raksul.com)
+- [Raiffeisen Schweiz Genossenschaft](https://www.raiffeisen.ch)
+- [RedHat](https://www.redhat.com)
+- [RepreZen API Studio](https://www.reprezen.com/swagger-openapi-code-generation-api-first-microservices-enterprise-development)
+- [REST United](https://restunited.com)
+- [Robocorp](https://www.robocorp.com)
+- [Robotinfra](https://www.robotinfra.com)
+- [SearchApi](https://www.searchapi.io/)
+- [SmartHR](https://smarthr.co.jp/)
+- [Sony Interactive Entertainment](https://www.sie.com/en/index.html)
+- [Splitit](https://www.splitit.com/)
+- [Stingray](http://www.stingray.com)
+- [Suva](https://www.suva.ch/)
+- [Svix](https://www.svix.com/)
+- [Telstra](https://dev.telstra.com)
+- [Tencent](https://www.tencent.com)
+- [The University of Aizu](https://www.u-aizu.ac.jp/en/)
+- [TINQIN](https://www.tinqin.com/)
+- [Translucent ApS](https://www.translucent.dk)
+- [TravelTime platform](https://www.traveltimeplatform.com/)
+- [TribalScale](https://www.tribalscale.com)
+- [Trifork](https://trifork.com)
+- [TUI InfoTec GmbH](http://www.tui-infotec.com/)
+- [Twilio](https://www.twilio.com/)
+- [Twitter](https://twitter.com)
+- [unblu inc.](https://www.unblu.com/)
+- [Veamly](https://www.veamly.com/)
+- [VMWare](https://www.vmware.com/)
+- [wbt-solutions](https://www.wbt-solutions.de/)
+- [Woleet](https://www.woleet.io/)
+- [WSO2](https://wso2.com/)
+- [Vouchery.io](https://vouchery.io)
+- [Xero](https://www.xero.com/)
+- [Yahoo Japan](https://www.yahoo.co.jp/)
+- [viadee](https://www.viadee.de/)
+- [Vonage](https://vonage.com)
+- [YITU Technology](https://www.yitutech.com/)
+- [Yelp](https://www.yelp.com/)
+- [Zalando](https://www.zalando.com)
+- [3DS Outscale](https://www.outscale.com/)
 
 ## [5 - Presentations/Videos/Tutorials/Books](#table-of-contents)
 
 [](#5---presentationsvideostutorialsbooks)
 
--   2018/05/12 - [OpenAPI Generator - community drivenで成長するコードジェネレータ](https://ackintosh.github.io/blog/2018/05/12/openapi-generator/) by [中野暁人](https://github.com/ackintosh)
--   2018/05/15 - [Starting a new open-source project](http://jmini.github.io/blog/2018/2018-05-15_new-open-source-project.html) by [Jeremie Bresson](https://github.com/jmini)
--   2018/05/15 - [REST API仕様からAPIクライアントやスタブサーバを自動生成する「OpenAPI Generator」オープンソースで公開。Swagger Codegenからのフォーク](https://www.publickey1.jp/blog/18/rest_apiapiopenapi_generatorswagger_generator.html) by [Publickey](https://www.publickey1.jp)
--   2018/06/08 - [Swagger Codegen is now OpenAPI Generator](https://angular.schule/blog/2018-06-swagger-codegen-is-now-openapi-generator) by [JohannesHoppe](https://github.com/JohannesHoppe)
--   2018/06/21 - [Connect your JHipster apps to the world of APIs with OpenAPI and gRPC](https://fr.slideshare.net/chbornet/jhipster-conf-2018-connect-your-jhipster-apps-to-the-world-of-apis-with-openapi-and-grpc) by [Christophe Bornet](https://github.com/cbornet) at [JHipster Conf 2018](https://jhipster-conf.github.io/)
--   2018/06/22 - [OpenAPI Generator で Gatling Client を生成してみた](https://rohki.hatenablog.com/entry/2018/06/22/073000) at [ソモサン](https://rohki.hatenablog.com/)
--   2018/06/27 - [Lessons Learned from Leading an Open-Source Project Supporting 30+ Programming Languages](https://speakerdeck.com/wing328/lessons-learned-from-leading-an-open-source-project-supporting-30-plus-programming-languages) - [William Cheng](https://github.com/wing328) at [LinuxCon + ContainerCon + CloudOpen China 2018](http://bit.ly/2waDKKX)
--   2018/07/19 - [OpenAPI Generator Contribution Quickstart - RingCentral Go SDK](https://medium.com/ringcentral-developers/openapi-generator-for-go-contribution-quickstart-8cc72bf37b53) by [John Wang](https://github.com/grokify)
--   2018/08/22 - [OpenAPI Generatorのプロジェクト構成などのメモ](https://yinm.info/20180822/) by [Yusuke Iinuma](https://github.com/yinm)
--   2018/09/12 - [RepreZen and OpenAPI 3.0: Now is the Time](https://www.reprezen.com/blog/reprezen-openapi-3.0-upgrade-now-is-the-time) by [Miles Daffin](https://www.reprezen.com/blog/author/miles-daffin)
--   2018/10/31 - [A node package wrapper for openapi-generator](https://github.com/HarmoWatch/openapi-generator-cli)
--   2018/11/03 - [OpenAPI Generator + golang + Flutter でアプリ開発](http://ryuichi111std.hatenablog.com/entry/2018/11/03/214005) by [Ryuichi Daigo](https://github.com/ryuichi111)
--   2018/11/15 - [基于openapi3.0的yaml文件生成java代码的一次实践](https://blog.csdn.net/yzy199391/article/details/84023982) by [焱魔王](https://me.csdn.net/yzy199391)
--   2018/11/18 - [Generating PHP library code from OpenAPI](https://lornajane.net/posts/2018/generating-php-library-code-from-openapi) by [Lorna Jane](https://lornajane.net/) at [LORNAJANE Blog](https://lornajane.net/blog)
--   2018/11/19 - [OpenAPIs are everywhere](https://youtu.be/-lDot4Yn7Dg) by [Jeremie Bresson (Unblu)](https://github.com/jmini) at [EclipseCon Europe 2018](https://www.eclipsecon.org/europe2018)
--   2018/12/09 - [openapi-generator をカスタマイズする方法](https://qiita.com/watiko/items/0961287c02eac9211572) by [@watiko](https://qiita.com/watiko)
--   2019/01/03 - [Calling a Swagger service from Apex using openapi-generator](https://lekkimworld.com/2019/01/03/calling-a-swagger-service-from-apex-using-openapi-generator/) by [Mikkel Flindt Heisterberg](https://lekkimworld.com)
--   2019/01/13 - [OpenAPI GeneratorでRESTful APIの定義書から色々自動生成する](https://ky-yk-d.hatenablog.com/entry/2019/01/13/234108) by [@ky\_yk\_d](https://twitter.com/ky_yk_d)
--   2019/01/20 - [Contract-First API Development with OpenAPI Generator and Connexion](https://medium.com/commencis/contract-first-api-development-with-openapi-generator-and-connexion-b21bbf2f9244) by [Anil Can Aydin](https://github.com/anlcnydn)
--   2019/01/30 - [Rapid Application Development With API First Approach Using Open-API Generator](https://dzone.com/articles/rapid-api-development-using-open-api-generator) by [Milan Sonkar](https://dzone.com/users/828329/milan_sonkar.html)
--   2019/02/02 - [平静を保ち、コードを生成せよ 〜 OpenAPI Generator誕生の背景と軌跡 〜](https://speakerdeck.com/akihito_nakano/gunmaweb34) by [中野暁人](https://github.com/ackintosh) at [Gunma.web #34 スキーマ駆動開発](https://gunmaweb.connpass.com/event/113974/)
--   2019/02/20 - [An adventure in OpenAPI V3 code generation](https://mux.com/blog/an-adventure-in-openapi-v3-api-code-generation/) by [Phil Cluff](https://mux.com/blog/author/philc/)
--   2019/02/26 - [Building API Services: A Beginner’s Guide](https://medium.com/google-cloud/building-api-services-a-beginners-guide-7274ae4c547f) by [Ratros Y.](https://medium.com/@ratrosy) in [Google Cloud Platform Blog](https://medium.com/google-cloud)
--   2019/02/26 - [Building APIs with OpenAPI: Continued](https://medium.com/@ratrosy/building-apis-with-openapi-continued-5d0faaed32eb) by [Ratros Y.](https://medium.com/@ratrosy) in [Google Cloud Platform Blog](https://medium.com/google-cloud)
--   2019-03-07 - [OpenAPI Generator で Spring Boot と Angular をタイプセーフに繋ぐ](https://qiita.com/chibato/items/e4a748db12409b40c02f) by [Tomofumi Chiba](https://github.com/chibat)
--   2019-03-16 - [A Quick introduction to manual OpenAPI V3](https://vadosware.io/post/quick-intro-to-manual-openapi-v3/) by [vados](https://github.com/t3hmrman) at [VADOSWARE](https://vadosware.io)
--   2019-03-25 - [Access any REST service with the SAP S/4HANA Cloud SDK](https://blogs.sap.com/2019/03/25/integrate-sap-s4hana-cloud-sdk-with-open-api/) by [Alexander Duemont](https://people.sap.com/alexander.duemont)
--   2019-03-25 - [OpenAPI generatorを試してみる](https://qiita.com/amuyikam/items/e8a45daae59c68be0fc8) by [@amuyikam](https://twitter.com/amuyikam)
--   2019-03-27 - [OpenAPI3を使ってみよう！Go言語でクライアントとスタブの自動生成まで！](https://techblog.zozo.com/entry/openapi3/go) by [@gold\_kou](https://twitter.com/gold_kou)
--   2019-04-17 - [OpenAPIによるスキーマファースト開発の実施サンプルとCloud Runについて](https://tech-blog.optim.co.jp/entry/2019/04/17/174000) by [@yukey1031](https://twitter.com/yukey1031)
--   2019-04-18 - [How to use OpenAPI3 for API developer (RubyKaigi 2019)](https://speakerdeck.com/ota42y/how-to-use-openapi3-for-api-developer) by [@ota42y](https://twitter.com/ota42y) at [RubyKaigi 2019](https://rubykaigi.org/2019)
--   2019-04-29 - [A Beginner's Guide to Code Generation for REST APIs (OpenAPI Generator)](https://gum.co/openapi_generator_ebook) by [William Cheng](https://twitter.com/wing328)
--   2019-05-01 - [Design and generate a REST API from Swagger / OpenAPI in Java, Python, C# and more](https://simply-how.com/design-and-generate-api-code-from-openapi) by [Simply How](https://simply-how.com/)
--   2019-05-17 - [Generate Spring Boot REST API using Swagger/OpenAPI](https://www.47northlabs.com/knowledge-base/generate-spring-boot-rest-api-using-swagger-openapi/) by [Antonie Zafirov](https://www.47northlabs.com/author/antonie-zafirov/)
--   2019-05-22 - [REST APIs代码生成指南(OpenAPI Generator)](https://gum.co/openapi_generator_ebook_gb) by [William Cheng](https://twitter.com/wing328), [Xin Meng](https://github.com/xmeng1)
--   2019-05-24 - [REST API 代碼生成指南 (OpenAPI Generator)](https://gum.co/openapi_generator_ebook_big5) by [William Cheng](https://twitter.com/wing328)
--   2019-06-24 - [Kubernetes Clients and OpenAPI Generator](https://speakerdeck.com/wing328/kubernetes-clients-and-openapi-generator) by [William Cheng](https://twitter.com/wing328) at [Kubernetes Contributor Summits Shanghai 2019](https://www.lfasiallc.com/events/contributors-summit-china-2019/)
--   2019-06-28 [Codewind OpenAPI Tools](https://marketplace.eclipse.org/content/codewind-openapi-tools) in [Eclipse Marketplace](https://marketplace.eclipse.org/) by IBM
--   2019-06-29 [Codewind OpenAPI Tools](https://marketplace.visualstudio.com/items?itemName=IBM.codewind-openapi-tools) in [Visual Studio Marketplace](https://marketplace.visualstudio.com/) by IBM
--   2019-07-04 - [REST API のためのコード生成入門 (OpenAPI Generator)](https://gum.co/openapi_generator_ebook_big5) by [William Cheng](https://twitter.com/wing328), [中野暁人](https://github.com/ackintosh), [和田拓朗](https://github.com/taxpon)
--   2019-07-08 - [OpenAPI Generator にコントリビュートしたら社名が載った話。(CAM) - CAM TECH BLOG](https://tech.cam-inc.co.jp/entry/2019/07/08/140000) by [CAM, Inc.](https://www.cam-inc.co.jp/)
--   2019-07-14 - [OpenAPI GeneratorでPythonのクライアントライブラリを作成した](https://qiita.com/yuji38kwmt/items/dfb929316a1335a161c0) by [yuji38kwmt](https://qiita.com/yuji38kwmt)
--   2019-07-19 - [Developer Experience (DX) for Open-Source Projects: How to Engage Developers and Build a Growing Developer Community](https://speakerdeck.com/wing328/developer-experience-dx-for-open-source-projects-english-japanese) by [William Cheng](https://twitter.com/wing328), [中野暁人](https://github.com/ackintosh) at [Open Source Summit Japan 2019](https://events.linuxfoundation.org/events/open-source-summit-japan-2019/)
--   2019-08-14 - [Our OpenAPI journey with Standardizing SDKs](https://bitmovin.com/our-openapi-journey-with-standardizing-sdks/) by [Sebastian Burgstaller](https://bitmovin.com/author/sburgstaller/) at [Bitmovin](https://www.bitmovin.com)
--   2019-08-15 - [APIのコードを自動生成させたいだけならgRPCでなくてもよくない?](https://www.m3tech.blog/entry/2019/08/15/110000) by [M3, Inc.](https://corporate.m3.com/)
--   2019-08-22 - [マイクロサービスにおけるWeb APIスキーマの管理─ GraphQL、gRPC、OpenAPIの特徴と使いどころ](https://employment.en-japan.com/engineerhub/entry/2019/08/22/103000) by [@ota42y](https://twitter.com/ota42y)
--   2019-08-24 - [SwaggerドキュメントからOpenAPI Generatorを使ってモックサーバー作成](https://qiita.com/masayoshi0222/items/4845e4c715d04587c104) by [坂本正義](https://qiita.com/masayoshi0222)
--   2019-08-29 - [OpenAPI初探](https://cloud.tencent.com/developer/article/1495986) by [peakxie](https://cloud.tencent.com/developer/user/1113152) at [腾讯云社区](https://cloud.tencent.com/developer)
--   2019-08-29 - [全面进化：Kubernetes CRD 1.16 GA前瞻](https://www.servicemesher.com/blog/kubernetes-1.16-crd-ga-preview/) by [Min Kim](https://github.com/yue9944882) at [ServiceMesher Blog](https://www.servicemesher.com/blog/)
--   2019-09-01 - [Creating a PHP-Slim server using OpenAPI (Youtube video)](https://www.youtube.com/watch?v=5cJtbIrsYkg) by [Daniel Persson](https://www.youtube.com/channel/UCnG-TN23lswO6QbvWhMtxpA)
--   2019-09-06 - [Vert.x and OpenAPI](https://wissel.net/blog/2019/09/vertx-and-openapi.html) by [Stephan H Wissel](https://twitter.com/notessensei) at [wissel.net blog](https://wissel.net)
--   2019-09-09 - [Cloud-native development - Creating RESTful microservices](https://cloud.ibm.com/docs/cloud-native?topic=cloud-native-rest-api) in [IBM Cloud Docs](https://cloud.ibm.com/docs)
--   2019-09-14 - [Generating and Configuring a Mastercard API Client](https://developer.mastercard.com/platform/documentation/generating-and-configuring-a-mastercard-api-client/) at [Mastercard Developers Platform](https://developer.mastercard.com/platform/documentation/)
--   2019-09-15 - [OpenAPI(Swagger)導入下調べ](https://qiita.com/ShoichiKuraoka/items/f1f7a3c2376f7cd9c56a) by [Shoichi Kuraoka](https://qiita.com/ShoichiKuraoka)
--   2019-09-17 - [Tutorial: Documenting http4k APIs with OpenApi3](https://www.http4k.org/tutorials/documenting_apis_with_openapi/) by [http4k](https://www.http4k.org/)
--   2019-09-22 - [OpenAPI 3を完全に理解できる本](https://booth.pm/ja/items/1571902) by [@ota42y](https://twitter.com/ota42y)
--   2019-09-22 - [RESTful APIs: Tutorial of OpenAPI Specification](https://medium.com/@amirm.lavasani/restful-apis-tutorial-of-openapi-specification-eeada0e3901d) by [Amir Lavasani](https://medium.com/@amirm.lavasani)
--   2019-09-22 - [Redefining SDKs as software diversity kits](https://devrel.net/dev-rel/redefining-sdks-as-software-diversity-kits) by [Sid Maestre (Xero)](https://twitter.com/sidneyallen) at [DevRelCon San Francisco 2019](https://sf2019.devrel.net/)
--   2019-09-23 - [swaggerからOpenApi GeneratorでSpringのコードを自動生成](https://qiita.com/littleFeet/items/492df2ad68a0799a5e5e) by [@littleFeet](https://qiita.com/littleFeet) at [Qiita](https://qiita.com/)
--   2019-09-24 - [Eine Stunde was mit Api First!](https://www.slideshare.net/JanWeinschenker/eine-stunde-was-mit-api-first) by [@janweinschenker](https://twitter.com/janweinschenker) at [Java Forum Nord](https://javaforumnord.de/)
--   2019-10-09 - [openapi-generator で生成した Go クライアントで Bearer 認証をする](https://autopp-tech.hatenablog.com/entry/2019/10/09/222039) by [Akira Tanimura](https://github.com/autopp)
--   2019-10-10 - [Automatic Generation of REST Clients](https://www.meetup.com/fr-FR/Criteo-Labs-Tech-Talks/events/264775768/) by Thomas Peyrard, Senior Software Engineer at Criteo in [Full-Stack Tech Talks (Meetup)](https://www.meetup.com/fr-FR/Criteo-Labs-Tech-Talks/events/264775768/)
--   2019-10-12 - [OpenApi自动生成client](https://blog.csdn.net/wxid2798226/article/details/102527467) by [郑泽洲](https://me.csdn.net/wxid2798226)
--   2019-10-16 - [How to ship APIs faster?](https://medium.com/@accounts_76224/how-to-ship-apis-faster-cabef2f819e4) by [Simon Guilliams @ PoniCode](https://ponicode.dev)
--   2019-10-22 - [OpenAPI + Spring Boot(Kotlin)でファイルダウンロードAPIを作成する](https://qiita.com/boronngo/items/4b78b92526209daeaee9) by [Yuki Furukawa](https://twitter.com/yuki_furukawa5)
--   2019-10-24 - [Microprofile OpenAPI - Code First or Design First?](https://github.com/pe-st/apidocs/blob/master/MicroProfile-OpenAPI-all-slides.pdf) by [Peter \[pɛʃə\] Steiner](https://twitter.com/pesche) at [eclipsecon Europe 2019](https://www.eclipsecon.org/europe2019/sessions/microprofile-openapi-code-first-or-design-first)
--   2019-11-06 - [Generating API clients based on OpenAPI v3 specifications](https://98elements.com/blog/generating-api-clients-based-on-openapi-v3-specifications) by [Dominik Jastrzębski @ 98elements](https://98elements.com)
--   2019-11-06 - [OpenAPIを利用して自前のAPIサーバー(Sinatra)を移植した時のメモ](https://qiita.com/YasuhiroABE/items/c73920eab2d9d6e97fd9) by [Yasuhiro ABE](https://twitter.com/YasuhiroABE)
--   2019-11-07 - [API First development with OpenAPI - You should you practise it !?](https://www.youtube.com/watch?v=F9iF3a1Z8Y8) by [Nick Van Hoof](https://www.nickvanhoof.com/) at [Devoxx Belgium 2019](https://devoxx.be/)
--   2019-11-08 - [JHipster beyond CRUD - API-First for Enterprises by Enrico Costanzi](https://www.youtube.com/watch?v=m28JFovKQ20) by [Enrico Costanzi](https://twitter.com/enricocostanzi) at [JHipster Conf 2019 in Paris](https://jhipster-conf.github.io/)
--   2019-11-11 - [TypeScript REST APIクライアント](https://qiita.com/unhurried/items/7b74f7d3c43545dadd2b) by [@unhurried](https://qiita.com/unhurried)
--   2019-11-11 - [One Spec to Rule them all - OpenAPI in Action](https://www.youtube.com/watch?v=MMay_nht8ec) by [Andreas Litt](https://github.com/littldr) at [code.talks 2019](https://www.codetalks.com/)
--   2019-11-13 - [OpenAPI 3.0 Editor And Generator With A Spring Boot Example](https://simply-how.com/design-and-generate-api-code-from-openapi) at [Simply How](https://simply-how.com/)
--   2019-11-17 - [OpenAPI Generator YouTube playlist](https://www.youtube.com/playlist?list=PLtJyHVMdzfF6fBkOUV5VDVErP23CGgHIy) at [YouTube](https://www.youtube.com)
--   2019-11-20 - [Introduction to OpenAPI](https://noti.st/lornajane/HvDH7U/introduction-to-openapi) by [Lorna Mitchell](https://twitter.com/lornajane) at [GOTO Copenhagen 2019](https://gotocph.com/2019/)
--   2019-11-20 - [How to Generate Angular code from OpenAPI specifications](https://dotnetthoughts.net/how-to-generate-angular-code-from-openapi-specifications/) by Anuraj
--   2019-11-23 - [Swagger ではない OpenAPI Specification 3.0 による API サーバー開発](https://www.slideshare.net/techblogyahoo/swagger-openapi-specification-30-api) by [Tetsuya Morimoto](https://github.com/t2y) at [JJUG CCC 2019 Fall](https://ccc2019fall.java-users.jp/)
--   2019-11-24 - [Accelerate Flutter development with OpenAPI and Dart code generation](https://medium.com/@irinasouthwell_220/accelerate-flutter-development-with-openapi-and-dart-code-generation-1f16f8329a6a) by [Irina Southwell](https://medium.com/@irinasouthwell_220)
--   2019-11-25 - [openapi-generatorで手軽にスタブサーバとクライアントの生成](https://qiita.com/pochopocho13/items/8db662e1934fb2b408b8) by [@pochopocho13](https://twitter.com/pochopocho13)
--   2019-11-26 - [CordaCon 2019 Highlights: Braid Server and OpenAPI Generator for Corda Client API’s](https://blog.b9lab.com/cordacon-2019-highlights-braid-server-and-openapi-generator-for-corda-flows-api-s-d24179ccb27c) by [Adel Rustum](https://blog.b9lab.com/@adelrestom) at [B9lab](https://blog.b9lab.com/)
--   2019-12-03 - [A Road to Less Coding: Auto-Generate APILibrary](https://www.corda.net/blog/a-road-to-less-coding-auto-generate-apilibrary/) at [Corda Blog](https://www.corda.net/blog/)
--   2019-12-04 - [Angular＋NestJS＋OpenAPI（Swagger）でマイクロサービスを視野に入れた環境を考える](https://qiita.com/teracy55/items/0327c7a170ec772970c6) by [てらしー](https://twitter.com/teracy55)
--   2019-12-05 - [Code generation on the Java VM](https://speakerdeck.com/sullis/code-generation-on-the-java-vm-2019-12-05) by [Sean Sullivan](https://speakerdeck.com/sullis)
--   2019-12-17 - [OpenAPI Generator で OAuth2 アクセストークン発行のコードまで生成してみる](https://www.techscore.com/blog/2019/12/17/openapi-generator-oauth2-accesstoken/) by [TECHSCORE](https://www.techscore.com/blog/)
--   2019-12-23 - [Use Ada for Your Web Development](https://www.electronicdesign.com/technologies/embedded-revolution/article/21119177/use-ada-for-your-web-development) by [Stephane Carrez](https://github.com/stcarrez)
--   2019-12-23 - [OpenAPIのスキーマを分割・構造化していく方法](https://gift-tech.co.jp/articles/structured-openapi-schema) by [小飯塚達也](https://github.com/t2h5) at [GiFT, Inc](https://gift-tech.co.jp/)
--   2020-01-17 - [OpenAPI demo for Pulp 3.0 GA](https://www.youtube.com/watch?v=mFBP-M0ZPfw&t=178s) by [Pulp](https://www.youtube.com/channel/UCI43Ffs4VPDv7awXvvBJfRQ) at [Youtube](https://www.youtube.com/)
--   2020-01-19 - [Why document a REST API as code?](https://dev.to/rolfstreefkerk/why-document-a-rest-api-as-code-5e7p) by [Rolf Streefkerk](https://github.com/rpstreef) at [DEV Community](https://dev.to)
--   2020-01-28 - [Get Your Serverless Swagger Back with OpenAPI](https://dev.to/matttyler/get-your-serverless-swagger-back-with-openapi-48gc) by [Matt Tyler](https://dev.to/matttyler)
--   2020-01-30 - [OpenAPI Generatorへのコントリビュート](https://www.yutaka0m.work/entry/2020/01/30/163905) by [yutaka0m](https://github.com/yutaka0m)
--   2020-02-01 - [Using OpenAPI to Maximise Your Pulp 3 Experience](https://fosdem.org/2020/schedule/event/openapi/) by [Dennis Kliban](https://github.com/dkliban/) at [FOSDEM](https://fosdem.org/)
--   2020-02-07 - [Why you should use OpenAPI for your API design](https://www.youtube.com/watch?v=zhb7vUApLW8&t=927s) by [Nick Van Hoof](https://apiconference.net/speaker/nick-van-hoof/) at [API Conference](https://apiconference.net/)
--   2020-02-17 - [Rubynetes: using OpenAPI to validate Kubernetes configs](https://www.brightbox.com/blog/2020/02/17/using-openapi-to-validate-kubernetes-configs/) by Neil Wilson at [Brightbox](https://www.brightbox.com/)
--   2020-02-20 - [Building SDKs for the future](https://devblog.xero.com/building-sdks-for-the-future-b79ff726dfd6) by [Sid Maestre (Xero)](https://twitter.com/sidneyallen)
--   2020-02-27 - [Nuxt利用プロダクトでIE11と仲良くするためのE2E](https://tech.medpeer.co.jp/entry/e2e-ie11) at [Medpeer.co.jp Tech Blog](https://tech.medpeer.co.jp/)
--   2020-02-29 - [Providing Support to IoT Devices Deployed in Disconnected Rural Environment (Conference paper)](https://link.springer.com/chapter/10.1007/978-3-030-41494-8_14) by Sergio Laso, Daniel Flores-Martín, Juan Luis HerreraCarlos, CanalJuan Manuel, MurilloJavier Berrocal
--   2020-03-02 - [How To Generate Angular & Spring Code From OpenAPI Specification](https://www.mokkapps.de/blog/how-to-generate-angular-and-spring-code-from-open-api-specification/) by [Michael Hoffmann](https://www.mokkapps.de/)
--   2020-03-02 - [OpenAPI Generator + TypeScript で始める自動生成の型に守られた豊かなクライアント生活](https://gift-tech.co.jp/articles/openapi-generator-typescript) by [五百蔵 直樹](https://gift-tech.co.jp/members/naokiioroi) at [GiFT株式会社](https://gift-tech.co.jp/)
--   2020-03-10 - [OpenAPI Generator Meetup #1](https://speakerdeck.com/akihito_nakano/openapi-generator-meetup-number-1) by [中野暁人](https://github.com/ackintosh) at [OpenAPI Generator Meetup #1](https://openapi-generator-meetup.connpass.com/event/168187/)
--   2020-03-15 - [Load Testing Your API with Swagger/OpenAPI and k6](https://k6.io/blog/load-testing-your-api-with-swagger-openapi-and-k6)
--   2020-04-13 - [俺的【OAS】との向き合い方 (爆速でOpenAPIと友達になろう)](https://tech-blog.optim.co.jp/entry/2020/04/13/100000) in [OPTim Blog](https://tech-blog.optim.co.jp/)
--   2020-04-22 - [Introduction to OpenAPI Generator](https://nordicapis.com/introduction-to-openapi-generator/) by [Kristopher Sandoval](https://nordicapis.com/author/sandovaleffect/) in [Nordic APIs](https://nordicapis.com/)
--   2020-04-27 - [How we use Open API v3 specification to auto-generate API documentation, code-snippets and clients](https://medium.com/pdf-generator-api/how-we-use-open-api-v3-specification-to-auto-generate-api-documentation-code-snippets-and-clients-d127a3cea784) by [Tanel Tähepõld](https://medium.com/@tanel.tahepold)
--   2020-05-09 - [OpenAPIでお手軽にモックAPIサーバーを動かす](https://qiita.com/kasa_le/items/97ca6a8dd4605695c25c) by [Sachie Kamba](https://qiita.com/kasa_le)
--   2020-05-18 - [Spring Boot REST with OpenAPI 3](https://dev.to/alfonzjanfrithz/spring-boot-rest-with-openapi-3-59jm) by [Alfonz Jan Frithz](https://dev.to/alfonzjanfrithz)
--   2020-05-19 - [Dead Simple APIs with Open API](https://www.youtube.com/watch?v=sIaXmR6xRAw) by [Chris Tankersley](https://github.com/dragonmantank) at [Nexmo](https://developer.nexmo.com/)
--   2020-05-22 - [TypeScript REST API Client](https://dev.to/unhurried/typescript-rest-api-client-4in3) by ["unhurried"](https://dev.to/unhurried)
--   2020-05-28 - [【使用 lotify + Swagger 建置可共用的 LINE Notify bot】 - #NiJia @ Chatbot Developer Taiwan 第 #19 小聚](https://www.youtube.com/watch?v=agYVz6dzh1I) by [Chatbot Developer Taiwan](https://www.youtube.com/channel/UCxeYUyZNnHmpX23YNF-ewvw)
--   2020-05-28 - [Building APIs with Laravel using OpenAPI](https://www.youtube.com/watch?v=xexLvQqAhiA) by [Chris Tankersley](https://github.com/dragonmantank) at [Laracon EU](https://laracon.eu/)
--   2020-06-12 - [Interoperability by construction: code generation for Arrowhead Clients](https://ieeexplore.ieee.org/document/9274746) by Michele Albano, Brian Nielsen at [2020 IEEE Conference on Industrial Cyberphysical Systems (ICPS)](https://ieeexplore.ieee.org/xpl/conhome/9274544/proceeding)
--   2020-06-23 - [新規サーバーアプリケーションにTypeScriptを採用してみた](https://www.cam-inc.co.jp/news/20200623) at [CAM Tech Blog](https://www.cam-inc.co.jp/news/tech-blog/)
--   2020-06-29 - [Artifact Abstract: Deployment of APIs on Android Mobile Devices and Microcontrollers](https://ieeexplore.ieee.org/document/9127353) by [Sergio Laso ; Marino Linaje ; Jose Garcia-Alonso ; Juan M. Murillo ; Javier Berrocal](https://ieeexplore.ieee.org/document/9127353/authors#authors) at [2020 IEEE International Conference on Pervasive Computing and Communications (PerCom)](https://ieeexplore.ieee.org/xpl/conhome/9125449/proceeding)
--   2020-07-07 - [5 Best API Documentation Tools](https://blog.dreamfactory.com/5-best-api-documentation-tools/) by Susanna Bouse at [DreamFactory Blog](https://blog.dreamfactory.com/)
--   2020-07-12 - [Open API 3.0の定義からgolangのサーバコードのスケルトンを作成する](https://qiita.com/professor/items/4cbd04ec084d13057bc2) by [@professor (Qiita Blog)](https://qiita.com/professor)
--   2020-07-20 - [Datadog API client libraries now available for Java and Go](https://www.datadoghq.com/blog/java-go-libraries/) by Jordan Obey at [Datadog Blog](https://www.datadoghq.com/blog)
--   2020-07-23 - [Generate Client SDK for .NET Core using Open Api](https://dev.to/no0law1/generate-client-sdk-for-net-core-using-open-api-2dgh) by [Nuno Reis](https://dev.to/no0law1)
--   2020-07-26 - [Dartのhttp\_interceptorライブラリを使うと配列のクエリパラメータが消えてしまう件の応急処置](https://qiita.com/gyamoto/items/eeeff81b6770487319ed) by [@gyamoto](https://qiita.com/gyamoto)
--   2020-08-01 - [Generate Angular ReactiveForms from Swagger/OpenAPI](https://dev.to/martinmcwhorter/generate-angular-reactiveforms-from-swagger-openapi-35h9) by [Martin McWhorter](https://dev.to/martinmcwhorter)
--   2020-08-03 - [Criando Bibliotecas para APIs RESTful com OpenAPI, Swagger Editor e OpenAPI Generator](https://medium.com/@everisBrasil/criando-bibliotecas-para-apis-restful-com-openapi-swagger-editor-e-openapi-generator-75349a6420fd) by [everis Brasil (an NTT DATA Company)](https://medium.com/@everisBrasil)
--   2020-08-19 - [マイクロサービスを連携してみよう](https://thinkit.co.jp/article/17704) by [岡井 裕矢(おかい ゆうや)](https://thinkit.co.jp/author/17588), [泉 勝(いずみ まさる)](https://thinkit.co.jp/author/17705) at [Think IT（シンクイット）](https://thinkit.co.jp/)
--   2020-08-25 - [OpenAPI Generator と TypeScript で型安全にフロントエンド開発をしている話](https://tech.smarthr.jp/entry/2020/08/25/135631) at [SmartHR Tech Blog](https://tech.smarthr.jp/)
--   2020-09-10 - [Introduction to OpenAPI with Instana](https://www.instana.com/blog/introduction-to-openapi-with-instana/) by [Cedric Ziel](https://www.instana.com/blog/author/cedricziel/) at [Instana Blog](https://www.instana.com/blog/)
--   2020-09-17 - [Generate PowerShellSDK using openapi-generator](https://medium.com/@ghufz.learn/generate-powershellsdk-using-openapi-generator-33b700891e33) by [Ghufran Zahidi](https://medium.com/@ghufz.learn)
--   2020-09-24 - [How to automate API code generation (OpenAPI/Swagger) and boost productivity - Tutorial with React Native featuring TypeScript](https://medium.com/@sceleski/how-to-automate-api-code-generation-openapi-swagger-and-boost-productivity-1176a0056d8a) by [Sanjin Celeski](https://medium.com/@sceleski)
--   2020-09-25 - [Generate OpenAPI Angular Client](https://medium.com/@pguso/generate-openapi-angular-client-8c9288e8bbd4) by [Patric](https://medium.com/@pguso)
--   2020-10-24 - [Working with Microsoft Identity - React Native Client](https://www.josephguadagno.net/2020/10/24/working-with-microsoft-identity-react-native-client) by [Joseph Guadagno](https://www.josephguadagno.net/)
--   2020-10-31 - [\[B2\] OpenAPI Specification으로 타입-세이프하게 API 개발하기: 희망편 VS 절망편](https://www.youtube.com/watch?v=J4JHLESAiFk) by 최태건 at [FEConf 2020](https://2020.feconf.kr/)
--   2020-11-05 - [Automated REST-Api Code Generation: Wie IT-Systeme miteinander sprechen](https://www.massiveart.com/blog/automated-rest-api-code-generation-wie-it-systeme-miteinander-sprechen) by Stefan Rottensteiner at [MASSIVE ART Blog](https://www.massiveart.com/blog)
--   2020-12-01 - [OpenAPI GeneratorでGoのAPIサーバー/クライアントコードを自動生成する](https://qiita.com/saki-engineering/items/b20d8b6074c4da9664a5) by [@saki-engineering](https://qiita.com/saki-engineering)
--   2020-12-04 - [Scaling the Test Coverage of OpenAPI Generator for 30+ Programming Languages](https://www.youtube.com/watch?v=7Lke9dHRqT0) by [William Cheng](https://github.com/wing328) at [Open Source Summit Japan + Automotive Linux Summit 2020](https://events.linuxfoundation.org/archive/2020/open-source-summit-japan/) ([Slides](https://speakerdeck.com/wing328/scaling-the-test-coverage-of-openapi-generator-for-30-plus-programming-languages))
--   2020-12-09 - [プロジェクトにOpenAPI Generatorで自動生成された型付きAPI Clientを導入した話](https://qiita.com/yoshifujiT/items/905c18700ede23f40840) by [@yoshifujiT](https://github.com/yoshifujiT)
--   2020-12-15 - [Next.js + NestJS + GraphQLで変化に追従するフロントエンドへ 〜 ショッピングクーポンの事例紹介](https://techblog.yahoo.co.jp/entry/2020121530052952/) by [小倉 陸](https://github.com/ogugu9) at [Yahoo! JAPAN Tech Blog](https://techblog.yahoo.co.jp/)
--   2021-01-08 - [Hello, New API – Part 1](https://www.nginx.com/blog/hello-new-api-part-1/) by [Jeremy Schulman](https://www.nginx.com/people/jeremy-schulman/) at [Major League Baseball](https://www.mlb.com)
--   2021-01-18 - [「アプリ開発あるある」を疑うことから始まった、API Clientコードの自動生成【デブスト2020】](https://codezine.jp/article/detail/13406?p=2) by [CodeZine編集部](https://codezine.jp/author/1)
--   2021-02-05 - [REST-API-Roundtrip with SpringDoc and OpenAPI Generator](https://blog.viadee.de/en/rest-api-roundtrip) by [Benjamin Klatt](https://twitter.com/benklatt) at [viadee](https://www.viadee.de/en/)
--   2021-02-17 - [REST-API-Roundtrip with SpringDoc and OpenAPI Generator](https://medium.com/nerd-for-tech/rest-api-roundtrip-with-springdoc-and-openapi-generator-30bd27ccf698) by [cloud @viadee](https://cloud-viadee.medium.com/)
--   2021-03-08 - [OpenAPI Generator 工具的躺坑尝试](https://blog.csdn.net/u013019701/article/details/114531975) by [独家雨天](https://blog.csdn.net/u013019701) at [CSDN官方博客](https://blog.csdn.net/)
--   2021-03-16 - [如何基于 Swagger 使用 OpenAPI Generator 生成 JMeter 脚本？](https://cloud.tencent.com/developer/article/1802704) by [高楼Zee](https://cloud.tencent.com/developer/user/5836255) at [腾讯云专栏](https://cloud.tencent.com/developer/column)
--   2021-03-24 - [openapi-generator-cli による TypeScript 型定義](https://zenn.dev/takepepe/articles/openapi-generator-cli-ts) by [Takefumi Yoshii](https://zenn.dev/takepepe)
--   2021-03-28 - [Trying out NestJS part 4: Generate Typescript clients from OpenAPI documents](https://dev.to/arnaudcortisse/trying-out-nestjs-part-4-generate-typescript-clients-from-openapi-documents-28mk) by [Arnaud Cortisse](https://dev.to/arnaudcortisse)
--   2021-03-31 - [Open API Server Implementation Using OpenAPI Generator](https://www.baeldung.com/java-openapi-generator-server) at [Baeldung](https://www.baeldung.com/)
--   2021-03-31 - [使用OpenAPI Generator實現Open API Server](https://www.1ju.org/article/java-openapi-generator-server) at [億聚網](https://www.1ju.org/)
--   2021-04-19 - [Introducing Twilio’s OpenAPI Specification Beta](https://www.twilio.com/blog/introducing-twilio-open-api-specification-beta) by [GARETH PAUL JONES](https://www.twilio.com/blog/author/gpj) at [Twilio Blog](https://www.twilio.com/blog)
--   2021-04-22 - [Leveraging OpenApi strengths in a Micro-Service environment](https://medium.com/unibuddy-technology-blog/leveraging-openapi-strengths-in-a-micro-service-environment-3d7f9e7c26ff) by Nicolas Jellab at [Unibuddy Technology Blog](https://medium.com/unibuddy-technology-blog)
--   2021-04-27 - [From zero to publishing PowerShell API clients in PowerShell Gallery within minutes](https://speakerdeck.com/wing328/from-zero-to-publishing-powershell-api-clients-in-powershell-gallery-within-minutes) by [William Cheng](https://github.com/wing328) at [PowerShell + DevOps Global Summit 2021](https://events.devopscollective.org/event/powershell-devops-global-summit-2021/)
--   2021-05-31 - [FlutterでOpen Api Generator(Swagger)を使う](https://aakira.app/blog/2021/05/flutter-open-api/) by [AAkira](https://twitter.com/_a_akira)
--   2021-06-22 - [Rest API Documentation and Client Generation With OpenAPI](https://dzone.com/articles/rest-api-documentation-and-client-generation-with) by [Prasanth Gullapalli](https://dzone.com/users/1011797/prasanthnath.g@gmail.com.html)
--   2021-07-16 - [銀行事業のサーバーサイド開発について / LINE 京都開発室 エンジニア採用説明会](https://www.youtube.com/watch?v=YrrKQHxLPpQ) by 野田誠人, Robert Mitchell
--   2021-07-19 - [OpenAPI code generation with kotlin](https://sylhare.github.io/2021/07/19/Openapi-swagger-codegen-with-kotlin.html) by [sylhare](https://github.com/sylhare)
--   2021-07-29 - [How To Rewrite a Huge Codebase](https://dzone.com/articles/how-to-rewrite-a-huge-code-base) by [Curtis Poe](https://dzone.com/users/4565446/publiusovidius.html)
--   2021-08-21 - [Generating Client APIs using Swagger Part 1](https://medium.com/@flowsquad/generating-client-apis-using-swagger-part-1-2d46f13f5e92) by [FlowSquad.io](https://medium.com/@flowsquad)
--   2021-09-11 - [Invoking AWS ParallelCluster API](https://docs.aws.amazon.com/parallelcluster/latest/ug/api-reference-v3.html) at [AWS ParallelCluster API official documentation](https://docs.aws.amazon.com/parallelcluster/latest/ug/api-reference-v3.html)
--   2021-09-20 - [OpenAPI Generator - The Babel Fish of the API World](https://www.youtube.com/watch?v=s2zMtwd5klg) by [Cliffano Subagio (Principal Engineer at Shine Solutions)](https://github.com/cliffano) at [Apidays LIVE Australia 2021](https://www.apidays.global/australia2021/)
--   2021-10-02 - [How to Write Fewer Lines of Code with the OpenAPI Generator](https://hackernoon.com/how-to-write-fewer-lines-of-code-with-the-openapi-generator) by [Mikhail Alfa](https://hackernoon.com/u/alphamikle)
--   2021-10-12 - [OpenAPI Generator : 4000 étoiles sur GitHub et des spaghettis](https://www.youtube.com/watch?v=9hEsNBSqTFk) by [Jérémie Bresson](https://github.com/jmini) at [Devoxx FR 2021](https://cfp.devoxx.fr/2021/speaker/jeremie_bresson)
--   2021-10-17 - [Generate a TypeScript HTTP Client From An OpenAPI Spec In DotNET 5](https://richardwillis.info/blog/generate-a-type-script-http-client-from-an-open-api-spec-in-dot-net-5) by [Richard Willis](https://github.com/badsyntax)
--   2021-11-06 - [スタートアップの開発で意識したこと](https://zenn.dev/woo_noo/articles/5cb09f8e2899ae782ad1) by [woo-noo](https://zenn.dev/woo_noo)
--   2021-11-09 - [Effective Software Development using OpenAPI Generator](https://apexlabs.ai/post/effective-software-development-using-openapi-generator) by Ajil Oomme
--   2021-12-07 - [An Introduction to OpenAPI](https://betterprogramming.pub/4-use-cases-of-openapi-which-are-good-to-know-1a041f4ad71e) by [Na'aman Hirschfeld](https://naamanhirschfeld.medium.com/)
--   2022-01-02 - [Towards a secure API client generator for IoT devices](https://arxiv.org/abs/2201.00270) by Anders Aaen Springborg, Martin Kaldahl Andersen, Kaare Holland Hattel, Michele Albano
--   2022-02-02 - [Use OpenApi generator to share your models between Flutter and your backend](https://www.youtube.com/watch?v=kPW7ccu9Yvk) by [Guillaume Bernos](https://feb2022.fluttervikings.com/speakers/guillaume_bernos) at [Flutter Vikings Conference 2022 (Hybrid)](https://feb2022.fluttervikings.com/)
--   2022-03-15 - [OpenAPI Specでハイフン区切りのEnum値をOpenAPI Generatorで出力すると、ハイフン区切りのまま出力される](https://qiita.com/yuji38kwmt/items/824d74d4889055ab37d8) by [yuji38kwmt](https://qiita.com/yuji38kwmt)
--   2022-04-01 - [OpenAPI Generatorのコード生成とSpring Frameworkのカスタムデータバインディングを共存させる](https://techblog.zozo.com/entry/coexistence-of-openapi-and-spring) in [ZOZO Tech Blog](https://techblog.zozo.com/)
--   2022-04-06 - [Effective Software Development using OpenAPI Generator](https://apexlabs.ai/post/openapi-generator) by Ajil Oommen (Senior Flutter Developer)
--   2022-05-13 - [A Path From an API To Client Libraries](https://www.youtube.com/watch?v=XC8oVn_efTw) by [Filip Srnec](https://www.devoxx.co.uk/talk/?id=11211) at Infobip
--   2022-06-01 - [API First, using OpenAPI and Spring Boot](https://medium.com/xgeeks/api-first-using-openapi-and-spring-boot-2602c04bb0d3) by [Micael Estrázulas Vianna](https://estrazulas.medium.com/)
--   2022-06-10 - [Autogenerating Clients with FastAPI and Github Actions](https://www.propelauth.com/post/autogenerating-clients-with-fastapi-and-github-actions) by [Andrew Israel](https://www.propelauth.com/author/andrew)
--   2022-06-12 - [Mustache templates with OpenAPI specs](https://medium.com/geekculture/mustache-templates-with-openapi-specs-f24711c67dec) by [Beppe Catanese](https://github.com/gcatanese)
--   2022-07-01 - [Generate API contract using OpenAPI Generator Maven plugin](https://huongdanjava.com/generate-api-contract-using-openapi-generator-maven-plugin.html) by [Khanh Nguyen](https://huongdanjava.com/)
--   2022-07-22 - [使用OpenAPI Generator Maven plugin开发api优先的java客户端和服务端代码](https://blog.roccoshi.top/2022/java/openapi-generator%E7%9A%84%E4%BD%BF%E7%94%A8/) by [Lincest](https://github.com/Lincest)
--   2022-08-01 - [Tutorial: Etsy Open API v3 (ruby)](https://blog.tjoyal.dev/etsy-open-api-v3/) by [Thierry Joyal](https://github.com/tjoyal)
--   2022-09-03 - [OpenAPI Generator For Go Web Development](https://blog.kevinhu.me/2022/09/03/03-openapi-generator/) by [Kevin Hu](https://twitter.com/Oldgunix)
--   2022-10-01 - [OpenAPI Generatorをカスタマイズしたコードを生成する（Swagger Codegenとほぼ同じ）](https://nainaistar.hatenablog.com/entry/2022/10/03/120000) by [きり丸](https://twitter.com/nainaistar)
--   2022-10-21 - [Kotlin（Spring Boot）の API を OpenAPI Generator で自動生成](https://zenn.dev/msksgm/articles/20221021-kotlin-spring-openapi-generator) by [msksgm](https://zenn.dev/msksgm)
--   2022-10-26 - [Quarkus Insights #106: Quarkiverse Extension Spotlight: OpenApi Generator](https://www.youtube.com/watch?v=_s_if69t2iQ) by [Quarkusio](https://www.youtube.com/c/Quarkusio)
--   2022-11-28 - [The REST API implementation flow](https://tmsvr.com/openapi-code-generation-for-rest-apis/) by [Imre Tömösvári](https://tmsvr.com/author/imre/)
--   2022-12-13 - [API-First with Spring WebFlux and OpenAPI Generator](https://boottechnologies-ci.medium.com/api-first-with-spring-webflux-and-openapi-generator-38b7804c4ed4) by [Eric Anicet](https://boottechnologies-ci.medium.com/)
--   2023-01-06 - [Major Improvements with Helidon and OpenAPI](https://medium.com/helidon/major-improvements-with-helidon-and-openapi-f76a0951508e) by [Tim Quinn](https://medium.com/@tquinno600)
--   2023-02-02 - [Replacing Postman with the Jetbrains HTTP Client](https://lengrand.fr/replacing-postman-in-seconds-with-the-jetbrains-http-client/) by [julien Lengrand-Lambert](https://github.com/jlengrand)
--   2023-03-15 - [OpenAPI Generatorに適したOpenAPIの書き方](https://techblog.zozo.com/entry/how-to-write-openapi-for-openapi-generator) by [ZOZO Tech Blog](https://techblog.zozo.com/)
--   2023-03-19 - [EXOGEM: Extending OpenAPI Generator for Monitoring of RESTful APIs](https://link.springer.com/chapter/10.1007/978-3-031-26507-5_10) by Daniel Friis Holtebo, Jannik Lucas Sommer, Magnus Mølgaard Lund, Alessandro Tibo, Junior Dongo & Michele Albano at "ICSOC 2022: Service-Oriented Computing – ICSOC 2022 Workshops"
--   2023-03-28 - [API-First Design with OpenAPI Generator](https://www.linkedin.com/pulse/api-first-design-openapi-generator-jonathan-manera/) by [Jonathan Manera](https://www.linkedin.com/in/manerajona/)
--   2023-03-28 - [ハンズオンで学ぶサーバーサイド Kotlin（Spring Boot&Arrow&OpenAPI Generator）v1.0.1](https://zenn.dev/msksgm/books/implementing-server-side-kotlin-development) by [msk](https://zenn.dev/msksgm)
--   2023-04-01 - [OpenAPI Client Code Generation](https://testingboss.com/blog/openapi-client-generation/) by Kwo Ding
--   2023-04-27 - \[Create an Angular Client using OpenAPI Specifications\](Create an Angular Client using OpenAPI Specifications) by [Patric](https://pguso.medium.com/)
--   2023-05-16 - [Adyen for Java developers](https://www.adyen.com/blog/adyen-java-library) by [Beppe Catanese, Developer Advocate, Adyen](https://github.com/gcatanese)
--   2023-05-18 - [如何基于 Swagger 使用 OpenAPI Generator 生成 JMeter 脚本？](https://blog.51cto.com/u_15181572/6294974) by [高楼（Zee)](https://blog.51cto.com/u_15181572)
--   2023-06-28 - [Generate API contract using OpenAPI Generator Maven plugin](https://huongdanjava.com/generate-api-contract-using-openapi-generator-maven-plugin.html) by [Khanh Nguyen](https://huongdanjava.com/)
--   2023-06-30 - [Generate Client SDKs with OpenApi Generator in Springboot](https://medium.com/@ramavathvinayak/generate-client-sdks-with-openapi-generator-in-springboot-f9f012e73c0b) by [Vinayak Ramavath](https://medium.com/@ramavathvinayak)
--   2023-12-10 - [UnityでOpenAPI Generatorを使う](https://www.youtube.com/watch?v=CbNwKVV5LRM) by [Soup Tori](https://www.youtube.com/@souptori8417)
--   2024-01-24 - [Comment générer des stubs wiremock avec openapi generator](https://www.youtube.com/watch?v=0jhONfBrcKw) by [Alexis Couvreur](https://github.com/acouvreur)
--   2024-03-04 - [Generating TypeScript Types with OpenAPI for REST API Consumption](https://www.pullrequest.com/blog/generating-typescript-types-with-openapi-for-rest-api-consumption/) by [PullRequest](https://www.pullrequest.com/)
--   2024-03-07 - [Fully typed Web Apps with OpenAPI (Part 1)](https://medium.com/@gfox1984/fully-typed-web-apps-with-openapi-part-1-595d55766670) by [Guillaume Renard](https://medium.com/@gfox1984)
--   2024-03-08 - [Laravel OpenAPIによる "辛くない" スキーマ駆動開発](https://fortee.jp/phperkaigi-2024/proposal/9e2e6c38-d078-4efa-99b4-83ebf9033b34) by [KentarouTakeda](https://twitter.com/KentarouTakeda)
--   2024-04-04 - [Working with OpenAPI using Rust](https://www.shuttle.dev/blog/2024/04/04/using-openapi-rust) by [Joshua Mo](https://twitter.com/joshmo_dev)
--   2024-04-08 - [Implement API first strategy with OpenAPI generator plugin](https://medium.com/javarevisited/implement-api-first-strategy-with-openapi-generator-plugin-e4bbe7f0d778) by [Rui Zhou](https://medium.com/@wirelesser)
--   2024-05-06 - [OpenAPI Generator Custom Templates](https://www.javacodegeeks.com/openapi-generator-custom-templates.html) by [Mary Zheng](https://www.javacodegeeks.com/author/mary-zheng)
--   2025-02-09 - [Custom validation with OpenApiGenerator and Spring Boot 3](https://medium.com/@jugurtha.aitoufella/custom-validation-with-openapigenerator-and-spring-boot-3-34a656e815c8) by [Jugurtha Aitoufella](https://medium.com/@jugurtha.aitoufella)
--   2025-02-20 - [Optimizing API Integration in a Large React Application Using OpenAPI Generator](https://www.youtube.com/watch?v=-B33pQnGQUI) by Stefano Marzo
+- 2018/05/12 - [OpenAPI Generator - community driven で成長するコードジェネレータ](https://ackintosh.github.io/blog/2018/05/12/openapi-generator/) by [中野暁人](https://github.com/ackintosh)
+- 2018/05/15 - [Starting a new open-source project](http://jmini.github.io/blog/2018/2018-05-15_new-open-source-project.html) by [Jeremie Bresson](https://github.com/jmini)
+- 2018/05/15 - [REST API 仕様から API クライアントやスタブサーバを自動生成する「OpenAPI Generator」オープンソースで公開。Swagger Codegen からのフォーク](https://www.publickey1.jp/blog/18/rest_apiapiopenapi_generatorswagger_generator.html) by [Publickey](https://www.publickey1.jp)
+- 2018/06/08 - [Swagger Codegen is now OpenAPI Generator](https://angular.schule/blog/2018-06-swagger-codegen-is-now-openapi-generator) by [JohannesHoppe](https://github.com/JohannesHoppe)
+- 2018/06/21 - [Connect your JHipster apps to the world of APIs with OpenAPI and gRPC](https://fr.slideshare.net/chbornet/jhipster-conf-2018-connect-your-jhipster-apps-to-the-world-of-apis-with-openapi-and-grpc) by [Christophe Bornet](https://github.com/cbornet) at [JHipster Conf 2018](https://jhipster-conf.github.io/)
+- 2018/06/22 - [OpenAPI Generator で Gatling Client を生成してみた](https://rohki.hatenablog.com/entry/2018/06/22/073000) at [ソモサン](https://rohki.hatenablog.com/)
+- 2018/06/27 - [Lessons Learned from Leading an Open-Source Project Supporting 30+ Programming Languages](https://speakerdeck.com/wing328/lessons-learned-from-leading-an-open-source-project-supporting-30-plus-programming-languages) - [William Cheng](https://github.com/wing328) at [LinuxCon + ContainerCon + CloudOpen China 2018](http://bit.ly/2waDKKX)
+- 2018/07/19 - [OpenAPI Generator Contribution Quickstart - RingCentral Go SDK](https://medium.com/ringcentral-developers/openapi-generator-for-go-contribution-quickstart-8cc72bf37b53) by [John Wang](https://github.com/grokify)
+- 2018/08/22 - [OpenAPI Generator のプロジェクト構成などのメモ](https://yinm.info/20180822/) by [Yusuke Iinuma](https://github.com/yinm)
+- 2018/09/12 - [RepreZen and OpenAPI 3.0: Now is the Time](https://www.reprezen.com/blog/reprezen-openapi-3.0-upgrade-now-is-the-time) by [Miles Daffin](https://www.reprezen.com/blog/author/miles-daffin)
+- 2018/10/31 - [A node package wrapper for openapi-generator](https://github.com/HarmoWatch/openapi-generator-cli)
+- 2018/11/03 - [OpenAPI Generator + golang + Flutter でアプリ開発](http://ryuichi111std.hatenablog.com/entry/2018/11/03/214005) by [Ryuichi Daigo](https://github.com/ryuichi111)
+- 2018/11/15 - [基于 openapi3.0 的 yaml 文件生成 java 代码的一次实践](https://blog.csdn.net/yzy199391/article/details/84023982) by [焱魔王](https://me.csdn.net/yzy199391)
+- 2018/11/18 - [Generating PHP library code from OpenAPI](https://lornajane.net/posts/2018/generating-php-library-code-from-openapi) by [Lorna Jane](https://lornajane.net/) at [LORNAJANE Blog](https://lornajane.net/blog)
+- 2018/11/19 - [OpenAPIs are everywhere](https://youtu.be/-lDot4Yn7Dg) by [Jeremie Bresson (Unblu)](https://github.com/jmini) at [EclipseCon Europe 2018](https://www.eclipsecon.org/europe2018)
+- 2018/12/09 - [openapi-generator をカスタマイズする方法](https://qiita.com/watiko/items/0961287c02eac9211572) by [@watiko](https://qiita.com/watiko)
+- 2019/01/03 - [Calling a Swagger service from Apex using openapi-generator](https://lekkimworld.com/2019/01/03/calling-a-swagger-service-from-apex-using-openapi-generator/) by [Mikkel Flindt Heisterberg](https://lekkimworld.com)
+- 2019/01/13 - [OpenAPI Generator で RESTful API の定義書から色々自動生成する](https://ky-yk-d.hatenablog.com/entry/2019/01/13/234108) by [@ky_yk_d](https://twitter.com/ky_yk_d)
+- 2019/01/20 - [Contract-First API Development with OpenAPI Generator and Connexion](https://medium.com/commencis/contract-first-api-development-with-openapi-generator-and-connexion-b21bbf2f9244) by [Anil Can Aydin](https://github.com/anlcnydn)
+- 2019/01/30 - [Rapid Application Development With API First Approach Using Open-API Generator](https://dzone.com/articles/rapid-api-development-using-open-api-generator) by [Milan Sonkar](https://dzone.com/users/828329/milan_sonkar.html)
+- 2019/02/02 - [平静を保ち、コードを生成せよ 〜 OpenAPI Generator 誕生の背景と軌跡 〜](https://speakerdeck.com/akihito_nakano/gunmaweb34) by [中野暁人](https://github.com/ackintosh) at [Gunma.web #34 スキーマ駆動開発](https://gunmaweb.connpass.com/event/113974/)
+- 2019/02/20 - [An adventure in OpenAPI V3 code generation](https://mux.com/blog/an-adventure-in-openapi-v3-api-code-generation/) by [Phil Cluff](https://mux.com/blog/author/philc/)
+- 2019/02/26 - [Building API Services: A Beginner’s Guide](https://medium.com/google-cloud/building-api-services-a-beginners-guide-7274ae4c547f) by [Ratros Y.](https://medium.com/@ratrosy) in [Google Cloud Platform Blog](https://medium.com/google-cloud)
+- 2019/02/26 - [Building APIs with OpenAPI: Continued](https://medium.com/@ratrosy/building-apis-with-openapi-continued-5d0faaed32eb) by [Ratros Y.](https://medium.com/@ratrosy) in [Google Cloud Platform Blog](https://medium.com/google-cloud)
+- 2019-03-07 - [OpenAPI Generator で Spring Boot と Angular をタイプセーフに繋ぐ](https://qiita.com/chibato/items/e4a748db12409b40c02f) by [Tomofumi Chiba](https://github.com/chibat)
+- 2019-03-16 - [A Quick introduction to manual OpenAPI V3](https://vadosware.io/post/quick-intro-to-manual-openapi-v3/) by [vados](https://github.com/t3hmrman) at [VADOSWARE](https://vadosware.io)
+- 2019-03-25 - [Access any REST service with the SAP S/4HANA Cloud SDK](https://blogs.sap.com/2019/03/25/integrate-sap-s4hana-cloud-sdk-with-open-api/) by [Alexander Duemont](https://people.sap.com/alexander.duemont)
+- 2019-03-25 - [OpenAPI generator を試してみる](https://qiita.com/amuyikam/items/e8a45daae59c68be0fc8) by [@amuyikam](https://twitter.com/amuyikam)
+- 2019-03-27 - [OpenAPI3 を使ってみよう！Go 言語でクライアントとスタブの自動生成まで！](https://techblog.zozo.com/entry/openapi3/go) by [@gold_kou](https://twitter.com/gold_kou)
+- 2019-04-17 - [OpenAPI によるスキーマファースト開発の実施サンプルと Cloud Run について](https://tech-blog.optim.co.jp/entry/2019/04/17/174000) by [@yukey1031](https://twitter.com/yukey1031)
+- 2019-04-18 - [How to use OpenAPI3 for API developer (RubyKaigi 2019)](https://speakerdeck.com/ota42y/how-to-use-openapi3-for-api-developer) by [@ota42y](https://twitter.com/ota42y) at [RubyKaigi 2019](https://rubykaigi.org/2019)
+- 2019-04-29 - [A Beginner's Guide to Code Generation for REST APIs (OpenAPI Generator)](https://gum.co/openapi_generator_ebook) by [William Cheng](https://twitter.com/wing328)
+- 2019-05-01 - [Design and generate a REST API from Swagger / OpenAPI in Java, Python, C# and more](https://simply-how.com/design-and-generate-api-code-from-openapi) by [Simply How](https://simply-how.com/)
+- 2019-05-17 - [Generate Spring Boot REST API using Swagger/OpenAPI](https://www.47northlabs.com/knowledge-base/generate-spring-boot-rest-api-using-swagger-openapi/) by [Antonie Zafirov](https://www.47northlabs.com/author/antonie-zafirov/)
+- 2019-05-22 - [REST APIs 代码生成指南(OpenAPI Generator)](https://gum.co/openapi_generator_ebook_gb) by [William Cheng](https://twitter.com/wing328), [Xin Meng](https://github.com/xmeng1)
+- 2019-05-24 - [REST API 代碼生成指南 (OpenAPI Generator)](https://gum.co/openapi_generator_ebook_big5) by [William Cheng](https://twitter.com/wing328)
+- 2019-06-24 - [Kubernetes Clients and OpenAPI Generator](https://speakerdeck.com/wing328/kubernetes-clients-and-openapi-generator) by [William Cheng](https://twitter.com/wing328) at [Kubernetes Contributor Summits Shanghai 2019](https://www.lfasiallc.com/events/contributors-summit-china-2019/)
+- 2019-06-28 [Codewind OpenAPI Tools](https://marketplace.eclipse.org/content/codewind-openapi-tools) in [Eclipse Marketplace](https://marketplace.eclipse.org/) by IBM
+- 2019-06-29 [Codewind OpenAPI Tools](https://marketplace.visualstudio.com/items?itemName=IBM.codewind-openapi-tools) in [Visual Studio Marketplace](https://marketplace.visualstudio.com/) by IBM
+- 2019-07-04 - [REST API のためのコード生成入門 (OpenAPI Generator)](https://gum.co/openapi_generator_ebook_big5) by [William Cheng](https://twitter.com/wing328), [中野暁人](https://github.com/ackintosh), [和田拓朗](https://github.com/taxpon)
+- 2019-07-08 - [OpenAPI Generator にコントリビュートしたら社名が載った話。(CAM) - CAM TECH BLOG](https://tech.cam-inc.co.jp/entry/2019/07/08/140000) by [CAM, Inc.](https://www.cam-inc.co.jp/)
+- 2019-07-14 - [OpenAPI Generator で Python のクライアントライブラリを作成した](https://qiita.com/yuji38kwmt/items/dfb929316a1335a161c0) by [yuji38kwmt](https://qiita.com/yuji38kwmt)
+- 2019-07-19 - [Developer Experience (DX) for Open-Source Projects: How to Engage Developers and Build a Growing Developer Community](https://speakerdeck.com/wing328/developer-experience-dx-for-open-source-projects-english-japanese) by [William Cheng](https://twitter.com/wing328), [中野暁人](https://github.com/ackintosh) at [Open Source Summit Japan 2019](https://events.linuxfoundation.org/events/open-source-summit-japan-2019/)
+- 2019-08-14 - [Our OpenAPI journey with Standardizing SDKs](https://bitmovin.com/our-openapi-journey-with-standardizing-sdks/) by [Sebastian Burgstaller](https://bitmovin.com/author/sburgstaller/) at [Bitmovin](https://www.bitmovin.com)
+- 2019-08-15 - [API のコードを自動生成させたいだけなら gRPC でなくてもよくない?](https://www.m3tech.blog/entry/2019/08/15/110000) by [M3, Inc.](https://corporate.m3.com/)
+- 2019-08-22 - [マイクロサービスにおける Web API スキーマの管理 ─ GraphQL、gRPC、OpenAPI の特徴と使いどころ](https://employment.en-japan.com/engineerhub/entry/2019/08/22/103000) by [@ota42y](https://twitter.com/ota42y)
+- 2019-08-24 - [Swagger ドキュメントから OpenAPI Generator を使ってモックサーバー作成](https://qiita.com/masayoshi0222/items/4845e4c715d04587c104) by [坂本正義](https://qiita.com/masayoshi0222)
+- 2019-08-29 - [OpenAPI 初探](https://cloud.tencent.com/developer/article/1495986) by [peakxie](https://cloud.tencent.com/developer/user/1113152) at [腾讯云社区](https://cloud.tencent.com/developer)
+- 2019-08-29 - [全面进化：Kubernetes CRD 1.16 GA 前瞻](https://www.servicemesher.com/blog/kubernetes-1.16-crd-ga-preview/) by [Min Kim](https://github.com/yue9944882) at [ServiceMesher Blog](https://www.servicemesher.com/blog/)
+- 2019-09-01 - [Creating a PHP-Slim server using OpenAPI (Youtube video)](https://www.youtube.com/watch?v=5cJtbIrsYkg) by [Daniel Persson](https://www.youtube.com/channel/UCnG-TN23lswO6QbvWhMtxpA)
+- 2019-09-06 - [Vert.x and OpenAPI](https://wissel.net/blog/2019/09/vertx-and-openapi.html) by [Stephan H Wissel](https://twitter.com/notessensei) at [wissel.net blog](https://wissel.net)
+- 2019-09-09 - [Cloud-native development - Creating RESTful microservices](https://cloud.ibm.com/docs/cloud-native?topic=cloud-native-rest-api) in [IBM Cloud Docs](https://cloud.ibm.com/docs)
+- 2019-09-14 - [Generating and Configuring a Mastercard API Client](https://developer.mastercard.com/platform/documentation/generating-and-configuring-a-mastercard-api-client/) at [Mastercard Developers Platform](https://developer.mastercard.com/platform/documentation/)
+- 2019-09-15 - [OpenAPI(Swagger)導入下調べ](https://qiita.com/ShoichiKuraoka/items/f1f7a3c2376f7cd9c56a) by [Shoichi Kuraoka](https://qiita.com/ShoichiKuraoka)
+- 2019-09-17 - [Tutorial: Documenting http4k APIs with OpenApi3](https://www.http4k.org/tutorials/documenting_apis_with_openapi/) by [http4k](https://www.http4k.org/)
+- 2019-09-22 - [OpenAPI 3 を完全に理解できる本](https://booth.pm/ja/items/1571902) by [@ota42y](https://twitter.com/ota42y)
+- 2019-09-22 - [RESTful APIs: Tutorial of OpenAPI Specification](https://medium.com/@amirm.lavasani/restful-apis-tutorial-of-openapi-specification-eeada0e3901d) by [Amir Lavasani](https://medium.com/@amirm.lavasani)
+- 2019-09-22 - [Redefining SDKs as software diversity kits](https://devrel.net/dev-rel/redefining-sdks-as-software-diversity-kits) by [Sid Maestre (Xero)](https://twitter.com/sidneyallen) at [DevRelCon San Francisco 2019](https://sf2019.devrel.net/)
+- 2019-09-23 - [swagger から OpenApi Generator で Spring のコードを自動生成](https://qiita.com/littleFeet/items/492df2ad68a0799a5e5e) by [@littleFeet](https://qiita.com/littleFeet) at [Qiita](https://qiita.com/)
+- 2019-09-24 - [Eine Stunde was mit Api First!](https://www.slideshare.net/JanWeinschenker/eine-stunde-was-mit-api-first) by [@janweinschenker](https://twitter.com/janweinschenker) at [Java Forum Nord](https://javaforumnord.de/)
+- 2019-10-09 - [openapi-generator で生成した Go クライアントで Bearer 認証をする](https://autopp-tech.hatenablog.com/entry/2019/10/09/222039) by [Akira Tanimura](https://github.com/autopp)
+- 2019-10-10 - [Automatic Generation of REST Clients](https://www.meetup.com/fr-FR/Criteo-Labs-Tech-Talks/events/264775768/) by Thomas Peyrard, Senior Software Engineer at Criteo in [Full-Stack Tech Talks (Meetup)](https://www.meetup.com/fr-FR/Criteo-Labs-Tech-Talks/events/264775768/)
+- 2019-10-12 - [OpenApi 自动生成 client](https://blog.csdn.net/wxid2798226/article/details/102527467) by [郑泽洲](https://me.csdn.net/wxid2798226)
+- 2019-10-16 - [How to ship APIs faster?](https://medium.com/@accounts_76224/how-to-ship-apis-faster-cabef2f819e4) by [Simon Guilliams @ PoniCode](https://ponicode.dev)
+- 2019-10-22 - [OpenAPI + Spring Boot(Kotlin)でファイルダウンロード API を作成する](https://qiita.com/boronngo/items/4b78b92526209daeaee9) by [Yuki Furukawa](https://twitter.com/yuki_furukawa5)
+- 2019-10-24 - [Microprofile OpenAPI - Code First or Design First?](https://github.com/pe-st/apidocs/blob/master/MicroProfile-OpenAPI-all-slides.pdf) by [Peter \[pɛʃə\] Steiner](https://twitter.com/pesche) at [eclipsecon Europe 2019](https://www.eclipsecon.org/europe2019/sessions/microprofile-openapi-code-first-or-design-first)
+- 2019-11-06 - [Generating API clients based on OpenAPI v3 specifications](https://98elements.com/blog/generating-api-clients-based-on-openapi-v3-specifications) by [Dominik Jastrzębski @ 98elements](https://98elements.com)
+- 2019-11-06 - [OpenAPI を利用して自前の API サーバー(Sinatra)を移植した時のメモ](https://qiita.com/YasuhiroABE/items/c73920eab2d9d6e97fd9) by [Yasuhiro ABE](https://twitter.com/YasuhiroABE)
+- 2019-11-07 - [API First development with OpenAPI - You should you practise it !?](https://www.youtube.com/watch?v=F9iF3a1Z8Y8) by [Nick Van Hoof](https://www.nickvanhoof.com/) at [Devoxx Belgium 2019](https://devoxx.be/)
+- 2019-11-08 - [JHipster beyond CRUD - API-First for Enterprises by Enrico Costanzi](https://www.youtube.com/watch?v=m28JFovKQ20) by [Enrico Costanzi](https://twitter.com/enricocostanzi) at [JHipster Conf 2019 in Paris](https://jhipster-conf.github.io/)
+- 2019-11-11 - [TypeScript REST API クライアント](https://qiita.com/unhurried/items/7b74f7d3c43545dadd2b) by [@unhurried](https://qiita.com/unhurried)
+- 2019-11-11 - [One Spec to Rule them all - OpenAPI in Action](https://www.youtube.com/watch?v=MMay_nht8ec) by [Andreas Litt](https://github.com/littldr) at [code.talks 2019](https://www.codetalks.com/)
+- 2019-11-13 - [OpenAPI 3.0 Editor And Generator With A Spring Boot Example](https://simply-how.com/design-and-generate-api-code-from-openapi) at [Simply How](https://simply-how.com/)
+- 2019-11-17 - [OpenAPI Generator YouTube playlist](https://www.youtube.com/playlist?list=PLtJyHVMdzfF6fBkOUV5VDVErP23CGgHIy) at [YouTube](https://www.youtube.com)
+- 2019-11-20 - [Introduction to OpenAPI](https://noti.st/lornajane/HvDH7U/introduction-to-openapi) by [Lorna Mitchell](https://twitter.com/lornajane) at [GOTO Copenhagen 2019](https://gotocph.com/2019/)
+- 2019-11-20 - [How to Generate Angular code from OpenAPI specifications](https://dotnetthoughts.net/how-to-generate-angular-code-from-openapi-specifications/) by Anuraj
+- 2019-11-23 - [Swagger ではない OpenAPI Specification 3.0 による API サーバー開発](https://www.slideshare.net/techblogyahoo/swagger-openapi-specification-30-api) by [Tetsuya Morimoto](https://github.com/t2y) at [JJUG CCC 2019 Fall](https://ccc2019fall.java-users.jp/)
+- 2019-11-24 - [Accelerate Flutter development with OpenAPI and Dart code generation](https://medium.com/@irinasouthwell_220/accelerate-flutter-development-with-openapi-and-dart-code-generation-1f16f8329a6a) by [Irina Southwell](https://medium.com/@irinasouthwell_220)
+- 2019-11-25 - [openapi-generator で手軽にスタブサーバとクライアントの生成](https://qiita.com/pochopocho13/items/8db662e1934fb2b408b8) by [@pochopocho13](https://twitter.com/pochopocho13)
+- 2019-11-26 - [CordaCon 2019 Highlights: Braid Server and OpenAPI Generator for Corda Client API’s](https://blog.b9lab.com/cordacon-2019-highlights-braid-server-and-openapi-generator-for-corda-flows-api-s-d24179ccb27c) by [Adel Rustum](https://blog.b9lab.com/@adelrestom) at [B9lab](https://blog.b9lab.com/)
+- 2019-12-03 - [A Road to Less Coding: Auto-Generate APILibrary](https://www.corda.net/blog/a-road-to-less-coding-auto-generate-apilibrary/) at [Corda Blog](https://www.corda.net/blog/)
+- 2019-12-04 - [Angular ＋ NestJS ＋ OpenAPI（Swagger）でマイクロサービスを視野に入れた環境を考える](https://qiita.com/teracy55/items/0327c7a170ec772970c6) by [てらしー](https://twitter.com/teracy55)
+- 2019-12-05 - [Code generation on the Java VM](https://speakerdeck.com/sullis/code-generation-on-the-java-vm-2019-12-05) by [Sean Sullivan](https://speakerdeck.com/sullis)
+- 2019-12-17 - [OpenAPI Generator で OAuth2 アクセストークン発行のコードまで生成してみる](https://www.techscore.com/blog/2019/12/17/openapi-generator-oauth2-accesstoken/) by [TECHSCORE](https://www.techscore.com/blog/)
+- 2019-12-23 - [Use Ada for Your Web Development](https://www.electronicdesign.com/technologies/embedded-revolution/article/21119177/use-ada-for-your-web-development) by [Stephane Carrez](https://github.com/stcarrez)
+- 2019-12-23 - [OpenAPI のスキーマを分割・構造化していく方法](https://gift-tech.co.jp/articles/structured-openapi-schema) by [小飯塚達也](https://github.com/t2h5) at [GiFT, Inc](https://gift-tech.co.jp/)
+- 2020-01-17 - [OpenAPI demo for Pulp 3.0 GA](https://www.youtube.com/watch?v=mFBP-M0ZPfw&t=178s) by [Pulp](https://www.youtube.com/channel/UCI43Ffs4VPDv7awXvvBJfRQ) at [Youtube](https://www.youtube.com/)
+- 2020-01-19 - [Why document a REST API as code?](https://dev.to/rolfstreefkerk/why-document-a-rest-api-as-code-5e7p) by [Rolf Streefkerk](https://github.com/rpstreef) at [DEV Community](https://dev.to)
+- 2020-01-28 - [Get Your Serverless Swagger Back with OpenAPI](https://dev.to/matttyler/get-your-serverless-swagger-back-with-openapi-48gc) by [Matt Tyler](https://dev.to/matttyler)
+- 2020-01-30 - [OpenAPI Generator へのコントリビュート](https://www.yutaka0m.work/entry/2020/01/30/163905) by [yutaka0m](https://github.com/yutaka0m)
+- 2020-02-01 - [Using OpenAPI to Maximise Your Pulp 3 Experience](https://fosdem.org/2020/schedule/event/openapi/) by [Dennis Kliban](https://github.com/dkliban/) at [FOSDEM](https://fosdem.org/)
+- 2020-02-07 - [Why you should use OpenAPI for your API design](https://www.youtube.com/watch?v=zhb7vUApLW8&t=927s) by [Nick Van Hoof](https://apiconference.net/speaker/nick-van-hoof/) at [API Conference](https://apiconference.net/)
+- 2020-02-17 - [Rubynetes: using OpenAPI to validate Kubernetes configs](https://www.brightbox.com/blog/2020/02/17/using-openapi-to-validate-kubernetes-configs/) by Neil Wilson at [Brightbox](https://www.brightbox.com/)
+- 2020-02-20 - [Building SDKs for the future](https://devblog.xero.com/building-sdks-for-the-future-b79ff726dfd6) by [Sid Maestre (Xero)](https://twitter.com/sidneyallen)
+- 2020-02-27 - [Nuxt 利用プロダクトで IE11 と仲良くするための E2E](https://tech.medpeer.co.jp/entry/e2e-ie11) at [Medpeer.co.jp Tech Blog](https://tech.medpeer.co.jp/)
+- 2020-02-29 - [Providing Support to IoT Devices Deployed in Disconnected Rural Environment (Conference paper)](https://link.springer.com/chapter/10.1007/978-3-030-41494-8_14) by Sergio Laso, Daniel Flores-Martín, Juan Luis HerreraCarlos, CanalJuan Manuel, MurilloJavier Berrocal
+- 2020-03-02 - [How To Generate Angular & Spring Code From OpenAPI Specification](https://www.mokkapps.de/blog/how-to-generate-angular-and-spring-code-from-open-api-specification/) by [Michael Hoffmann](https://www.mokkapps.de/)
+- 2020-03-02 - [OpenAPI Generator + TypeScript で始める自動生成の型に守られた豊かなクライアント生活](https://gift-tech.co.jp/articles/openapi-generator-typescript) by [五百蔵 直樹](https://gift-tech.co.jp/members/naokiioroi) at [GiFT 株式会社](https://gift-tech.co.jp/)
+- 2020-03-10 - [OpenAPI Generator Meetup #1](https://speakerdeck.com/akihito_nakano/openapi-generator-meetup-number-1) by [中野暁人](https://github.com/ackintosh) at [OpenAPI Generator Meetup #1](https://openapi-generator-meetup.connpass.com/event/168187/)
+- 2020-03-15 - [Load Testing Your API with Swagger/OpenAPI and k6](https://k6.io/blog/load-testing-your-api-with-swagger-openapi-and-k6)
+- 2020-04-13 - [俺的【OAS】との向き合い方 (爆速で OpenAPI と友達になろう)](https://tech-blog.optim.co.jp/entry/2020/04/13/100000) in [OPTim Blog](https://tech-blog.optim.co.jp/)
+- 2020-04-22 - [Introduction to OpenAPI Generator](https://nordicapis.com/introduction-to-openapi-generator/) by [Kristopher Sandoval](https://nordicapis.com/author/sandovaleffect/) in [Nordic APIs](https://nordicapis.com/)
+- 2020-04-27 - [How we use Open API v3 specification to auto-generate API documentation, code-snippets and clients](https://medium.com/pdf-generator-api/how-we-use-open-api-v3-specification-to-auto-generate-api-documentation-code-snippets-and-clients-d127a3cea784) by [Tanel Tähepõld](https://medium.com/@tanel.tahepold)
+- 2020-05-09 - [OpenAPI でお手軽にモック API サーバーを動かす](https://qiita.com/kasa_le/items/97ca6a8dd4605695c25c) by [Sachie Kamba](https://qiita.com/kasa_le)
+- 2020-05-18 - [Spring Boot REST with OpenAPI 3](https://dev.to/alfonzjanfrithz/spring-boot-rest-with-openapi-3-59jm) by [Alfonz Jan Frithz](https://dev.to/alfonzjanfrithz)
+- 2020-05-19 - [Dead Simple APIs with Open API](https://www.youtube.com/watch?v=sIaXmR6xRAw) by [Chris Tankersley](https://github.com/dragonmantank) at [Nexmo](https://developer.nexmo.com/)
+- 2020-05-22 - [TypeScript REST API Client](https://dev.to/unhurried/typescript-rest-api-client-4in3) by ["unhurried"](https://dev.to/unhurried)
+- 2020-05-28 - [【使用 lotify + Swagger 建置可共用的 LINE Notify bot】 - #NiJia @ Chatbot Developer Taiwan 第 #19 小聚](https://www.youtube.com/watch?v=agYVz6dzh1I) by [Chatbot Developer Taiwan](https://www.youtube.com/channel/UCxeYUyZNnHmpX23YNF-ewvw)
+- 2020-05-28 - [Building APIs with Laravel using OpenAPI](https://www.youtube.com/watch?v=xexLvQqAhiA) by [Chris Tankersley](https://github.com/dragonmantank) at [Laracon EU](https://laracon.eu/)
+- 2020-06-12 - [Interoperability by construction: code generation for Arrowhead Clients](https://ieeexplore.ieee.org/document/9274746) by Michele Albano, Brian Nielsen at [2020 IEEE Conference on Industrial Cyberphysical Systems (ICPS)](https://ieeexplore.ieee.org/xpl/conhome/9274544/proceeding)
+- 2020-06-23 - [新規サーバーアプリケーションに TypeScript を採用してみた](https://www.cam-inc.co.jp/news/20200623) at [CAM Tech Blog](https://www.cam-inc.co.jp/news/tech-blog/)
+- 2020-06-29 - [Artifact Abstract: Deployment of APIs on Android Mobile Devices and Microcontrollers](https://ieeexplore.ieee.org/document/9127353) by [Sergio Laso ; Marino Linaje ; Jose Garcia-Alonso ; Juan M. Murillo ; Javier Berrocal](https://ieeexplore.ieee.org/document/9127353/authors#authors) at [2020 IEEE International Conference on Pervasive Computing and Communications (PerCom)](https://ieeexplore.ieee.org/xpl/conhome/9125449/proceeding)
+- 2020-07-07 - [5 Best API Documentation Tools](https://blog.dreamfactory.com/5-best-api-documentation-tools/) by Susanna Bouse at [DreamFactory Blog](https://blog.dreamfactory.com/)
+- 2020-07-12 - [Open API 3.0 の定義から golang のサーバコードのスケルトンを作成する](https://qiita.com/professor/items/4cbd04ec084d13057bc2) by [@professor (Qiita Blog)](https://qiita.com/professor)
+- 2020-07-20 - [Datadog API client libraries now available for Java and Go](https://www.datadoghq.com/blog/java-go-libraries/) by Jordan Obey at [Datadog Blog](https://www.datadoghq.com/blog)
+- 2020-07-23 - [Generate Client SDK for .NET Core using Open Api](https://dev.to/no0law1/generate-client-sdk-for-net-core-using-open-api-2dgh) by [Nuno Reis](https://dev.to/no0law1)
+- 2020-07-26 - [Dart の http_interceptor ライブラリを使うと配列のクエリパラメータが消えてしまう件の応急処置](https://qiita.com/gyamoto/items/eeeff81b6770487319ed) by [@gyamoto](https://qiita.com/gyamoto)
+- 2020-08-01 - [Generate Angular ReactiveForms from Swagger/OpenAPI](https://dev.to/martinmcwhorter/generate-angular-reactiveforms-from-swagger-openapi-35h9) by [Martin McWhorter](https://dev.to/martinmcwhorter)
+- 2020-08-03 - [Criando Bibliotecas para APIs RESTful com OpenAPI, Swagger Editor e OpenAPI Generator](https://medium.com/@everisBrasil/criando-bibliotecas-para-apis-restful-com-openapi-swagger-editor-e-openapi-generator-75349a6420fd) by [everis Brasil (an NTT DATA Company)](https://medium.com/@everisBrasil)
+- 2020-08-19 - [マイクロサービスを連携してみよう](https://thinkit.co.jp/article/17704) by [岡井 裕矢(おかい ゆうや)](https://thinkit.co.jp/author/17588), [泉 勝(いずみ まさる)](https://thinkit.co.jp/author/17705) at [Think IT（シンクイット）](https://thinkit.co.jp/)
+- 2020-08-25 - [OpenAPI Generator と TypeScript で型安全にフロントエンド開発をしている話](https://tech.smarthr.jp/entry/2020/08/25/135631) at [SmartHR Tech Blog](https://tech.smarthr.jp/)
+- 2020-09-10 - [Introduction to OpenAPI with Instana](https://www.instana.com/blog/introduction-to-openapi-with-instana/) by [Cedric Ziel](https://www.instana.com/blog/author/cedricziel/) at [Instana Blog](https://www.instana.com/blog/)
+- 2020-09-17 - [Generate PowerShellSDK using openapi-generator](https://medium.com/@ghufz.learn/generate-powershellsdk-using-openapi-generator-33b700891e33) by [Ghufran Zahidi](https://medium.com/@ghufz.learn)
+- 2020-09-24 - [How to automate API code generation (OpenAPI/Swagger) and boost productivity - Tutorial with React Native featuring TypeScript](https://medium.com/@sceleski/how-to-automate-api-code-generation-openapi-swagger-and-boost-productivity-1176a0056d8a) by [Sanjin Celeski](https://medium.com/@sceleski)
+- 2020-09-25 - [Generate OpenAPI Angular Client](https://medium.com/@pguso/generate-openapi-angular-client-8c9288e8bbd4) by [Patric](https://medium.com/@pguso)
+- 2020-10-24 - [Working with Microsoft Identity - React Native Client](https://www.josephguadagno.net/2020/10/24/working-with-microsoft-identity-react-native-client) by [Joseph Guadagno](https://www.josephguadagno.net/)
+- 2020-10-31 - [\[B2\] OpenAPI Specification으로 타입-세이프하게 API 개발하기: 희망편 VS 절망편](https://www.youtube.com/watch?v=J4JHLESAiFk) by 최태건 at [FEConf 2020](https://2020.feconf.kr/)
+- 2020-11-05 - [Automated REST-Api Code Generation: Wie IT-Systeme miteinander sprechen](https://www.massiveart.com/blog/automated-rest-api-code-generation-wie-it-systeme-miteinander-sprechen) by Stefan Rottensteiner at [MASSIVE ART Blog](https://www.massiveart.com/blog)
+- 2020-12-01 - [OpenAPI Generator で Go の API サーバー/クライアントコードを自動生成する](https://qiita.com/saki-engineering/items/b20d8b6074c4da9664a5) by [@saki-engineering](https://qiita.com/saki-engineering)
+- 2020-12-04 - [Scaling the Test Coverage of OpenAPI Generator for 30+ Programming Languages](https://www.youtube.com/watch?v=7Lke9dHRqT0) by [William Cheng](https://github.com/wing328) at [Open Source Summit Japan + Automotive Linux Summit 2020](https://events.linuxfoundation.org/archive/2020/open-source-summit-japan/) ([Slides](https://speakerdeck.com/wing328/scaling-the-test-coverage-of-openapi-generator-for-30-plus-programming-languages))
+- 2020-12-09 - [プロジェクトに OpenAPI Generator で自動生成された型付き API Client を導入した話](https://qiita.com/yoshifujiT/items/905c18700ede23f40840) by [@yoshifujiT](https://github.com/yoshifujiT)
+- 2020-12-15 - [Next.js + NestJS + GraphQL で変化に追従するフロントエンドへ 〜 ショッピングクーポンの事例紹介](https://techblog.yahoo.co.jp/entry/2020121530052952/) by [小倉 陸](https://github.com/ogugu9) at [Yahoo! JAPAN Tech Blog](https://techblog.yahoo.co.jp/)
+- 2021-01-08 - [Hello, New API – Part 1](https://www.nginx.com/blog/hello-new-api-part-1/) by [Jeremy Schulman](https://www.nginx.com/people/jeremy-schulman/) at [Major League Baseball](https://www.mlb.com)
+- 2021-01-18 - [「アプリ開発あるある」を疑うことから始まった、API Client コードの自動生成【デブスト 2020】](https://codezine.jp/article/detail/13406?p=2) by [CodeZine 編集部](https://codezine.jp/author/1)
+- 2021-02-05 - [REST-API-Roundtrip with SpringDoc and OpenAPI Generator](https://blog.viadee.de/en/rest-api-roundtrip) by [Benjamin Klatt](https://twitter.com/benklatt) at [viadee](https://www.viadee.de/en/)
+- 2021-02-17 - [REST-API-Roundtrip with SpringDoc and OpenAPI Generator](https://medium.com/nerd-for-tech/rest-api-roundtrip-with-springdoc-and-openapi-generator-30bd27ccf698) by [cloud @viadee](https://cloud-viadee.medium.com/)
+- 2021-03-08 - [OpenAPI Generator 工具的躺坑尝试](https://blog.csdn.net/u013019701/article/details/114531975) by [独家雨天](https://blog.csdn.net/u013019701) at [CSDN 官方博客](https://blog.csdn.net/)
+- 2021-03-16 - [如何基于 Swagger 使用 OpenAPI Generator 生成 JMeter 脚本？](https://cloud.tencent.com/developer/article/1802704) by [高楼 Zee](https://cloud.tencent.com/developer/user/5836255) at [腾讯云专栏](https://cloud.tencent.com/developer/column)
+- 2021-03-24 - [openapi-generator-cli による TypeScript 型定義](https://zenn.dev/takepepe/articles/openapi-generator-cli-ts) by [Takefumi Yoshii](https://zenn.dev/takepepe)
+- 2021-03-28 - [Trying out NestJS part 4: Generate Typescript clients from OpenAPI documents](https://dev.to/arnaudcortisse/trying-out-nestjs-part-4-generate-typescript-clients-from-openapi-documents-28mk) by [Arnaud Cortisse](https://dev.to/arnaudcortisse)
+- 2021-03-31 - [Open API Server Implementation Using OpenAPI Generator](https://www.baeldung.com/java-openapi-generator-server) at [Baeldung](https://www.baeldung.com/)
+- 2021-03-31 - [使用 OpenAPI Generator 實現 Open API Server](https://www.1ju.org/article/java-openapi-generator-server) at [億聚網](https://www.1ju.org/)
+- 2021-04-19 - [Introducing Twilio’s OpenAPI Specification Beta](https://www.twilio.com/blog/introducing-twilio-open-api-specification-beta) by [GARETH PAUL JONES](https://www.twilio.com/blog/author/gpj) at [Twilio Blog](https://www.twilio.com/blog)
+- 2021-04-22 - [Leveraging OpenApi strengths in a Micro-Service environment](https://medium.com/unibuddy-technology-blog/leveraging-openapi-strengths-in-a-micro-service-environment-3d7f9e7c26ff) by Nicolas Jellab at [Unibuddy Technology Blog](https://medium.com/unibuddy-technology-blog)
+- 2021-04-27 - [From zero to publishing PowerShell API clients in PowerShell Gallery within minutes](https://speakerdeck.com/wing328/from-zero-to-publishing-powershell-api-clients-in-powershell-gallery-within-minutes) by [William Cheng](https://github.com/wing328) at [PowerShell + DevOps Global Summit 2021](https://events.devopscollective.org/event/powershell-devops-global-summit-2021/)
+- 2021-05-31 - [Flutter で Open Api Generator(Swagger)を使う](https://aakira.app/blog/2021/05/flutter-open-api/) by [AAkira](https://twitter.com/_a_akira)
+- 2021-06-22 - [Rest API Documentation and Client Generation With OpenAPI](https://dzone.com/articles/rest-api-documentation-and-client-generation-with) by [Prasanth Gullapalli](https://dzone.com/users/1011797/prasanthnath.g@gmail.com.html)
+- 2021-07-16 - [銀行事業のサーバーサイド開発について / LINE 京都開発室 エンジニア採用説明会](https://www.youtube.com/watch?v=YrrKQHxLPpQ) by 野田誠人, Robert Mitchell
+- 2021-07-19 - [OpenAPI code generation with kotlin](https://sylhare.github.io/2021/07/19/Openapi-swagger-codegen-with-kotlin.html) by [sylhare](https://github.com/sylhare)
+- 2021-07-29 - [How To Rewrite a Huge Codebase](https://dzone.com/articles/how-to-rewrite-a-huge-code-base) by [Curtis Poe](https://dzone.com/users/4565446/publiusovidius.html)
+- 2021-08-21 - [Generating Client APIs using Swagger Part 1](https://medium.com/@flowsquad/generating-client-apis-using-swagger-part-1-2d46f13f5e92) by [FlowSquad.io](https://medium.com/@flowsquad)
+- 2021-09-11 - [Invoking AWS ParallelCluster API](https://docs.aws.amazon.com/parallelcluster/latest/ug/api-reference-v3.html) at [AWS ParallelCluster API official documentation](https://docs.aws.amazon.com/parallelcluster/latest/ug/api-reference-v3.html)
+- 2021-09-20 - [OpenAPI Generator - The Babel Fish of the API World](https://www.youtube.com/watch?v=s2zMtwd5klg) by [Cliffano Subagio (Principal Engineer at Shine Solutions)](https://github.com/cliffano) at [Apidays LIVE Australia 2021](https://www.apidays.global/australia2021/)
+- 2021-10-02 - [How to Write Fewer Lines of Code with the OpenAPI Generator](https://hackernoon.com/how-to-write-fewer-lines-of-code-with-the-openapi-generator) by [Mikhail Alfa](https://hackernoon.com/u/alphamikle)
+- 2021-10-12 - [OpenAPI Generator : 4000 étoiles sur GitHub et des spaghettis](https://www.youtube.com/watch?v=9hEsNBSqTFk) by [Jérémie Bresson](https://github.com/jmini) at [Devoxx FR 2021](https://cfp.devoxx.fr/2021/speaker/jeremie_bresson)
+- 2021-10-17 - [Generate a TypeScript HTTP Client From An OpenAPI Spec In DotNET 5](https://richardwillis.info/blog/generate-a-type-script-http-client-from-an-open-api-spec-in-dot-net-5) by [Richard Willis](https://github.com/badsyntax)
+- 2021-11-06 - [スタートアップの開発で意識したこと](https://zenn.dev/woo_noo/articles/5cb09f8e2899ae782ad1) by [woo-noo](https://zenn.dev/woo_noo)
+- 2021-11-09 - [Effective Software Development using OpenAPI Generator](https://apexlabs.ai/post/effective-software-development-using-openapi-generator) by Ajil Oomme
+- 2021-12-07 - [An Introduction to OpenAPI](https://betterprogramming.pub/4-use-cases-of-openapi-which-are-good-to-know-1a041f4ad71e) by [Na'aman Hirschfeld](https://naamanhirschfeld.medium.com/)
+- 2022-01-02 - [Towards a secure API client generator for IoT devices](https://arxiv.org/abs/2201.00270) by Anders Aaen Springborg, Martin Kaldahl Andersen, Kaare Holland Hattel, Michele Albano
+- 2022-02-02 - [Use OpenApi generator to share your models between Flutter and your backend](https://www.youtube.com/watch?v=kPW7ccu9Yvk) by [Guillaume Bernos](https://feb2022.fluttervikings.com/speakers/guillaume_bernos) at [Flutter Vikings Conference 2022 (Hybrid)](https://feb2022.fluttervikings.com/)
+- 2022-03-15 - [OpenAPI Spec でハイフン区切りの Enum 値を OpenAPI Generator で出力すると、ハイフン区切りのまま出力される](https://qiita.com/yuji38kwmt/items/824d74d4889055ab37d8) by [yuji38kwmt](https://qiita.com/yuji38kwmt)
+- 2022-04-01 - [OpenAPI Generator のコード生成と Spring Framework のカスタムデータバインディングを共存させる](https://techblog.zozo.com/entry/coexistence-of-openapi-and-spring) in [ZOZO Tech Blog](https://techblog.zozo.com/)
+- 2022-04-06 - [Effective Software Development using OpenAPI Generator](https://apexlabs.ai/post/openapi-generator) by Ajil Oommen (Senior Flutter Developer)
+- 2022-05-13 - [A Path From an API To Client Libraries](https://www.youtube.com/watch?v=XC8oVn_efTw) by [Filip Srnec](https://www.devoxx.co.uk/talk/?id=11211) at Infobip
+- 2022-06-01 - [API First, using OpenAPI and Spring Boot](https://medium.com/xgeeks/api-first-using-openapi-and-spring-boot-2602c04bb0d3) by [Micael Estrázulas Vianna](https://estrazulas.medium.com/)
+- 2022-06-10 - [Autogenerating Clients with FastAPI and Github Actions](https://www.propelauth.com/post/autogenerating-clients-with-fastapi-and-github-actions) by [Andrew Israel](https://www.propelauth.com/author/andrew)
+- 2022-06-12 - [Mustache templates with OpenAPI specs](https://medium.com/geekculture/mustache-templates-with-openapi-specs-f24711c67dec) by [Beppe Catanese](https://github.com/gcatanese)
+- 2022-07-01 - [Generate API contract using OpenAPI Generator Maven plugin](https://huongdanjava.com/generate-api-contract-using-openapi-generator-maven-plugin.html) by [Khanh Nguyen](https://huongdanjava.com/)
+- 2022-07-22 - [使用 OpenAPI Generator Maven plugin 开发 api 优先的 java 客户端和服务端代码](https://blog.roccoshi.top/2022/java/openapi-generator%E7%9A%84%E4%BD%BF%E7%94%A8/) by [Lincest](https://github.com/Lincest)
+- 2022-08-01 - [Tutorial: Etsy Open API v3 (ruby)](https://blog.tjoyal.dev/etsy-open-api-v3/) by [Thierry Joyal](https://github.com/tjoyal)
+- 2022-09-03 - [OpenAPI Generator For Go Web Development](https://blog.kevinhu.me/2022/09/03/03-openapi-generator/) by [Kevin Hu](https://twitter.com/Oldgunix)
+- 2022-10-01 - [OpenAPI Generator をカスタマイズしたコードを生成する（Swagger Codegen とほぼ同じ）](https://nainaistar.hatenablog.com/entry/2022/10/03/120000) by [きり丸](https://twitter.com/nainaistar)
+- 2022-10-21 - [Kotlin（Spring Boot）の API を OpenAPI Generator で自動生成](https://zenn.dev/msksgm/articles/20221021-kotlin-spring-openapi-generator) by [msksgm](https://zenn.dev/msksgm)
+- 2022-10-26 - [Quarkus Insights #106: Quarkiverse Extension Spotlight: OpenApi Generator](https://www.youtube.com/watch?v=_s_if69t2iQ) by [Quarkusio](https://www.youtube.com/c/Quarkusio)
+- 2022-11-28 - [The REST API implementation flow](https://tmsvr.com/openapi-code-generation-for-rest-apis/) by [Imre Tömösvári](https://tmsvr.com/author/imre/)
+- 2022-12-13 - [API-First with Spring WebFlux and OpenAPI Generator](https://boottechnologies-ci.medium.com/api-first-with-spring-webflux-and-openapi-generator-38b7804c4ed4) by [Eric Anicet](https://boottechnologies-ci.medium.com/)
+- 2023-01-06 - [Major Improvements with Helidon and OpenAPI](https://medium.com/helidon/major-improvements-with-helidon-and-openapi-f76a0951508e) by [Tim Quinn](https://medium.com/@tquinno600)
+- 2023-02-02 - [Replacing Postman with the Jetbrains HTTP Client](https://lengrand.fr/replacing-postman-in-seconds-with-the-jetbrains-http-client/) by [julien Lengrand-Lambert](https://github.com/jlengrand)
+- 2023-03-15 - [OpenAPI Generator に適した OpenAPI の書き方](https://techblog.zozo.com/entry/how-to-write-openapi-for-openapi-generator) by [ZOZO Tech Blog](https://techblog.zozo.com/)
+- 2023-03-19 - [EXOGEM: Extending OpenAPI Generator for Monitoring of RESTful APIs](https://link.springer.com/chapter/10.1007/978-3-031-26507-5_10) by Daniel Friis Holtebo, Jannik Lucas Sommer, Magnus Mølgaard Lund, Alessandro Tibo, Junior Dongo & Michele Albano at "ICSOC 2022: Service-Oriented Computing – ICSOC 2022 Workshops"
+- 2023-03-28 - [API-First Design with OpenAPI Generator](https://www.linkedin.com/pulse/api-first-design-openapi-generator-jonathan-manera/) by [Jonathan Manera](https://www.linkedin.com/in/manerajona/)
+- 2023-03-28 - [ハンズオンで学ぶサーバーサイド Kotlin（Spring Boot&Arrow&OpenAPI Generator）v1.0.1](https://zenn.dev/msksgm/books/implementing-server-side-kotlin-development) by [msk](https://zenn.dev/msksgm)
+- 2023-04-01 - [OpenAPI Client Code Generation](https://testingboss.com/blog/openapi-client-generation/) by Kwo Ding
+- 2023-04-27 - \[Create an Angular Client using OpenAPI Specifications\](Create an Angular Client using OpenAPI Specifications) by [Patric](https://pguso.medium.com/)
+- 2023-05-16 - [Adyen for Java developers](https://www.adyen.com/blog/adyen-java-library) by [Beppe Catanese, Developer Advocate, Adyen](https://github.com/gcatanese)
+- 2023-05-18 - [如何基于 Swagger 使用 OpenAPI Generator 生成 JMeter 脚本？](https://blog.51cto.com/u_15181572/6294974) by [高楼（Zee)](https://blog.51cto.com/u_15181572)
+- 2023-06-28 - [Generate API contract using OpenAPI Generator Maven plugin](https://huongdanjava.com/generate-api-contract-using-openapi-generator-maven-plugin.html) by [Khanh Nguyen](https://huongdanjava.com/)
+- 2023-06-30 - [Generate Client SDKs with OpenApi Generator in Springboot](https://medium.com/@ramavathvinayak/generate-client-sdks-with-openapi-generator-in-springboot-f9f012e73c0b) by [Vinayak Ramavath](https://medium.com/@ramavathvinayak)
+- 2023-12-10 - [Unity で OpenAPI Generator を使う](https://www.youtube.com/watch?v=CbNwKVV5LRM) by [Soup Tori](https://www.youtube.com/@souptori8417)
+- 2024-01-24 - [Comment générer des stubs wiremock avec openapi generator](https://www.youtube.com/watch?v=0jhONfBrcKw) by [Alexis Couvreur](https://github.com/acouvreur)
+- 2024-03-04 - [Generating TypeScript Types with OpenAPI for REST API Consumption](https://www.pullrequest.com/blog/generating-typescript-types-with-openapi-for-rest-api-consumption/) by [PullRequest](https://www.pullrequest.com/)
+- 2024-03-07 - [Fully typed Web Apps with OpenAPI (Part 1)](https://medium.com/@gfox1984/fully-typed-web-apps-with-openapi-part-1-595d55766670) by [Guillaume Renard](https://medium.com/@gfox1984)
+- 2024-03-08 - [Laravel OpenAPI による "辛くない" スキーマ駆動開発](https://fortee.jp/phperkaigi-2024/proposal/9e2e6c38-d078-4efa-99b4-83ebf9033b34) by [KentarouTakeda](https://twitter.com/KentarouTakeda)
+- 2024-04-04 - [Working with OpenAPI using Rust](https://www.shuttle.dev/blog/2024/04/04/using-openapi-rust) by [Joshua Mo](https://twitter.com/joshmo_dev)
+- 2024-04-08 - [Implement API first strategy with OpenAPI generator plugin](https://medium.com/javarevisited/implement-api-first-strategy-with-openapi-generator-plugin-e4bbe7f0d778) by [Rui Zhou](https://medium.com/@wirelesser)
+- 2024-05-06 - [OpenAPI Generator Custom Templates](https://www.javacodegeeks.com/openapi-generator-custom-templates.html) by [Mary Zheng](https://www.javacodegeeks.com/author/mary-zheng)
+- 2025-02-09 - [Custom validation with OpenApiGenerator and Spring Boot 3](https://medium.com/@jugurtha.aitoufella/custom-validation-with-openapigenerator-and-spring-boot-3-34a656e815c8) by [Jugurtha Aitoufella](https://medium.com/@jugurtha.aitoufella)
+- 2025-02-20 - [Optimizing API Integration in a Large React Application Using OpenAPI Generator](https://www.youtube.com/watch?v=-B33pQnGQUI) by Stefano Marzo
 
 ## [6 - About Us](#table-of-contents)
 
@@ -1498,11 +1509,11 @@ OpenAPI Generator core team members are contributors who have been making signif
 
 [](#core-team-members)
 
--   [@wing328](https://github.com/wing328) (2015/07) [❤️](https://www.patreon.com/wing328)
--   [@jimschubert](https://github.com/jimschubert) (2016/05) [❤️](https://www.patreon.com/jimschubert)
--   [@cbornet](https://github.com/cbornet) (2016/05)
--   [@jmini](https://github.com/jmini) (2018/04) [❤️](https://www.patreon.com/jmini)
--   [@etherealjoy](https://github.com/etherealjoy) (2019/06)
+- [@wing328](https://github.com/wing328) (2015/07) [❤️](https://www.patreon.com/wing328)
+- [@jimschubert](https://github.com/jimschubert) (2016/05) [❤️](https://www.patreon.com/jimschubert)
+- [@cbornet](https://github.com/cbornet) (2016/05)
+- [@jmini](https://github.com/jmini) (2018/04) [❤️](https://www.patreon.com/jmini)
+- [@etherealjoy](https://github.com/etherealjoy) (2019/06)
 
 ❤️ = Link to support the contributor directly
 
@@ -1510,186 +1521,186 @@ OpenAPI Generator core team members are contributors who have been making signif
 
 [](#template-creator)
 
-**NOTE**: Embedded templates are only supported in *Mustache* format. Support for all other formats is experimental and subject to change at any time.
+**NOTE**: Embedded templates are only supported in _Mustache_ format. Support for all other formats is experimental and subject to change at any time.
 
 Here is a list of template creators:
 
--   API Clients:
-    -   Ada: @stcarrez
-    -   Apex: @asnelling
-    -   Bash: @bkryza
-    -   C: @PowerOfCreation @zhemant [❤️](https://www.patreon.com/zhemant)
-    -   C++ REST: @Danielku15
-    -   C++ Tiny: @AndersSpringborg @kaareHH @michelealbano @mkakbas
-    -   C++ UE4: @Kahncode
-    -   C# (.NET 2.0): @who
-    -   C# (.NET Standard 1.3 ): @Gronsak
-    -   C# (.NET 4.5 refactored): @jimschubert [❤️](https://www.patreon.com/jimschubert)
-    -   C# (GenericHost): @devhl-labs
-    -   C# (HttpClient): @Blackclaws
-    -   Clojure: @xhh
-    -   Crystal: @wing328
-    -   Dart: @yissachar
-    -   Dart (refactor): @joernahrens
-    -   Dart 2: @swipesight
-    -   Dart (Jaguar): @jaumard
-    -   Dart (Dio): @josh-burton
-    -   Elixir: @niku
-    -   Elm: @eriktim
-    -   Eiffel: @jvelilla
-    -   Erlang: @tsloughter
-    -   Erlang (PropEr): @jfacorro @robertoaloi
-    -   Groovy: @victorgit
-    -   Go: @wing328 [❤️](https://www.patreon.com/wing328)
-    -   Go (rewritten in 2.3.0): @antihax
-    -   Godot (GDScript): @Goutte [❤️](https://liberapay.com/Goutte)
-    -   Haskell (http-client): @jonschoning
-    -   Java (Feign): @davidkiss
-    -   Java (Retrofit): @0legg
-    -   Java (Retrofit2): @emilianobonassi
-    -   Java (Jersey2): @xhh
-    -   Java (okhttp-gson): @xhh
-    -   Java (RestTemplate): @nbruno
-    -   Java (Spring 5 WebClient): @daonomic
-    -   Java (Spring 6 RestClient): @nicklas2751
-    -   Java (RESTEasy): @gayathrigs
-    -   Java (Vertx): @lopesmcc
-    -   Java (Google APIs Client Library): @charlescapps
-    -   Java (Rest-assured): @viclovsky
-    -   Java (Java 11 Native HTTP client): @bbdouglas
-    -   Java (Apache HttpClient 5.x): @harrywhite4 @andrevegas
-    -   Java (Helidon): @spericas @tjquinno @tvallin
-    -   Javascript/NodeJS: @jfiala
-    -   JavaScript (Apollo DataSource): @erithmetic
-    -   JavaScript (Closure-annotated Angular) @achew22
-    -   JavaScript (Flow types) @jaypea
-    -   Jetbrains HTTP Client : @jlengrand
-    -   JMeter: @davidkiss
-    -   Julia: @tanmaykm
-    -   Kotlin: @jimschubert [❤️](https://www.patreon.com/jimschubert)
-    -   Kotlin (MultiPlatform): @andrewemery
-    -   Kotlin (Volley): @alisters
-    -   Kotlin (jvm-spring-webclient): @stefankoppier
-    -   Kotlin (jvm-spring-restclient): @stefankoppier
-    -   Lua: @daurnimator
-    -   N4JS: @mmews-n4
-    -   Nim: @hokamoto
-    -   OCaml: @cgensoul
-    -   Perl: @wing328 [❤️](https://www.patreon.com/wing328)
-    -   PHP (Guzzle): @baartosz
-    -   PHP (with Data Transfer): @Articus
-    -   PowerShell: @beatcracker
-    -   PowerShell (refactored in 5.0.0): @wing328
-    -   Python: @spacether \[:heart:\]\[spacether sponsorship\]
-    -   Python-Experimental: @spacether \[:heart:\]\[spacether sponsorship\]
-    -   Python (refactored in 7.0.0): @wing328
-    -   R: @ramnov
-    -   Ruby (Faraday): @meganemura @dkliban
-    -   Ruby (HTTPX): @honeyryderchuck
-    -   Rust: @farcaller
-    -   Rust (rust-server): @metaswitch
-    -   Scala (scalaz & http4s): @tbrown1979
-    -   Scala (Akka): @cchafer
-    -   Scala (sttp): @chameleon82
-    -   Scala (sttp4): @flsh86
-    -   Scala (Pekko): @mickaelmagniez
-    -   Scala (http4s): @JennyLeahy
-    -   Swift: @tkqubo
-    -   Swift 3: @hexelon
-    -   Swift 4: @ehyche
-    -   Swift 5: @4brunu
-    -   Swift 6: @4brunu
-    -   Swift Combine: @dydus0x14
-    -   TypeScript (Angular1): @mhardorf
-    -   TypeScript (Angular2): @roni-frantchi
-    -   TypeScript (Angular6): @akehir
-    -   TypeScript (Angular7): @topce
-    -   TypeScript (Axios): @nicokoenig
-    -   TypeScript (Fetch): @leonyu
-    -   TypeScript (Inversify): @gualtierim
-    -   TypeScript (jQuery): @bherila
-    -   TypeScript (Nestjs): @vfrank66
-    -   TypeScript (Node): @mhardorf
-    -   TypeScript (Rxjs): @denyo
-    -   TypeScript (redux-query): @petejohansonxo
-    -   Xojo: @Topheee
-    -   Zapier: @valmoz, @emajo
--   Server Stubs
-    -   Ada: @stcarrez
-    -   C# ASP.NET 5: @jimschubert [❤️](https://www.patreon.com/jimschubert)
-    -   C# ASP.NET Core 3.0: @A-Joshi
-    -   C# APS.NET Core 3.1: @phatcher
-    -   C# Azure functions: @Abrhm7786
-    -   C# NancyFX: @mstefaniuk
-    -   C++ (Qt5 QHttpEngine): @etherealjoy
-    -   C++ Pistache: @sebymiano
-    -   C++ Restbed: @stkrwork
-    -   Erlang Server: @galaxie @nelsonvides
-    -   F# (Giraffe) Server: @nmfisher
-    -   Go Server: @guohuang
-    -   Go Server (refactored in 7.0.0): @lwj5
-    -   Go (Echo) Server: @ph4r5h4d
-    -   Go (Gin) Server: @kemokemo
-    -   GraphQL Express Server: @renepardon
-    -   Haskell Servant: @algas
-    -   Haskell Yesod: @yotsuya
-    -   Java Camel: @carnevalegiacomo
-    -   Java MSF4J: @sanjeewa-malalgoda
-    -   Java Spring Boot: @diyfr
-    -   Java Undertow: @stevehu
-    -   Java Play Framework: @JFCote
-    -   Java PKMST: @anshu2185 @sanshuman @rkumar-pk @ninodpillai
-    -   Java Vert.x: @lwlee2608
-    -   Java Micronaut: @andriy-dmytruk
-    -   Java Helidon: @spericas @tjquinno @tvallin
-    -   Java WireMock: [@acouvreur](https://github.com/acouvreur)
-    -   JAX-RS RestEasy: @chameleon82
-    -   JAX-RS CXF: @hiveship
-    -   JAX-RS CXF (CDI): @nickcmaynard
-    -   JAX-RS RestEasy (JBoss EAP): @jfiala
-    -   Julia: @tanmaykm
-    -   Kotlin: @jimschubert [❤️](https://www.patreon.com/jimschubert)
-    -   Kotlin (Spring Boot): @dr4ke616
-    -   Kotlin (Vertx): @Wooyme
-    -   Kotlin (JAX-RS): @anttileppa
-    -   Kotlin WireMock: @stefankoppier
-    -   NodeJS Express: @YishTish
-    -   PHP Flight: @daniel-sc
-    -   PHP Laravel: @renepardon
-    -   PHP Laravel (refactor in 7.12.0): @gijs-blanken
-    -   PHP Lumen: @abcsun
-    -   PHP Mezzio (with Path Handler): @Articus
-    -   PHP Slim: @jfastnacht
-    -   PHP Slim4: [@ybelenko](https://github.com/ybelenko)
-    -   PHP Symfony: @ksm2
-    -   PHP Symfony6: @BenjaminHae
-    -   Python FastAPI: @krjakbrjak
-    -   Python AIOHTTP:
-    -   Ruby on Rails 5: @zlx
-    -   Rust (rust-server): @metaswitch
-    -   Rust (rust-axum): @linxGnu
-    -   Scala Akka: @Bouillie
-    -   Scala Cask: @aaronp
-    -   Scala Finch: @jimschubert [❤️](https://www.patreon.com/jimschubert)
-    -   Scala Lagom: @gmkumar2005
-    -   Scala Play: @adigerber
--   Documentation
-    -   AsciiDoc: @man-at-home
-    -   HTML Doc 2: @jhitchcock
-    -   Confluence Wiki: @jhitchcock
-    -   PlantUML: @pburls
--   Configuration
-    -   Apache2: @stkrwork
-    -   k6: @mostafa
--   Schema
-    -   Avro: @sgadouar
-    -   GraphQL: @wing328 [❤️](https://www.patreon.com/wing328)
-    -   Ktorm: @Luiz-Monad
-    -   MySQL: [@ybelenko](https://github.com/ybelenko)
-    -   PostgreSQL: [@iri](https://github.com/iri)
-    -   Postman Collection: @gcatanese
-    -   Protocol Buffer: @wing328
-    -   WSDL: @adessoDpd
+- API Clients:
+  - Ada: @stcarrez
+  - Apex: @asnelling
+  - Bash: @bkryza
+  - C: @PowerOfCreation @zhemant [❤️](https://www.patreon.com/zhemant)
+  - C++ REST: @Danielku15
+  - C++ Tiny: @AndersSpringborg @kaareHH @michelealbano @mkakbas
+  - C++ UE4: @Kahncode
+  - C# (.NET 2.0): @who
+  - C# (.NET Standard 1.3 ): @Gronsak
+  - C# (.NET 4.5 refactored): @jimschubert [❤️](https://www.patreon.com/jimschubert)
+  - C# (GenericHost): @devhl-labs
+  - C# (HttpClient): @Blackclaws
+  - Clojure: @xhh
+  - Crystal: @wing328
+  - Dart: @yissachar
+  - Dart (refactor): @joernahrens
+  - Dart 2: @swipesight
+  - Dart (Jaguar): @jaumard
+  - Dart (Dio): @josh-burton
+  - Elixir: @niku
+  - Elm: @eriktim
+  - Eiffel: @jvelilla
+  - Erlang: @tsloughter
+  - Erlang (PropEr): @jfacorro @robertoaloi
+  - Groovy: @victorgit
+  - Go: @wing328 [❤️](https://www.patreon.com/wing328)
+  - Go (rewritten in 2.3.0): @antihax
+  - Godot (GDScript): @Goutte [❤️](https://liberapay.com/Goutte)
+  - Haskell (http-client): @jonschoning
+  - Java (Feign): @davidkiss
+  - Java (Retrofit): @0legg
+  - Java (Retrofit2): @emilianobonassi
+  - Java (Jersey2): @xhh
+  - Java (okhttp-gson): @xhh
+  - Java (RestTemplate): @nbruno
+  - Java (Spring 5 WebClient): @daonomic
+  - Java (Spring 6 RestClient): @nicklas2751
+  - Java (RESTEasy): @gayathrigs
+  - Java (Vertx): @lopesmcc
+  - Java (Google APIs Client Library): @charlescapps
+  - Java (Rest-assured): @viclovsky
+  - Java (Java 11 Native HTTP client): @bbdouglas
+  - Java (Apache HttpClient 5.x): @harrywhite4 @andrevegas
+  - Java (Helidon): @spericas @tjquinno @tvallin
+  - Javascript/NodeJS: @jfiala
+  - JavaScript (Apollo DataSource): @erithmetic
+  - JavaScript (Closure-annotated Angular) @achew22
+  - JavaScript (Flow types) @jaypea
+  - Jetbrains HTTP Client : @jlengrand
+  - JMeter: @davidkiss
+  - Julia: @tanmaykm
+  - Kotlin: @jimschubert [❤️](https://www.patreon.com/jimschubert)
+  - Kotlin (MultiPlatform): @andrewemery
+  - Kotlin (Volley): @alisters
+  - Kotlin (jvm-spring-webclient): @stefankoppier
+  - Kotlin (jvm-spring-restclient): @stefankoppier
+  - Lua: @daurnimator
+  - N4JS: @mmews-n4
+  - Nim: @hokamoto
+  - OCaml: @cgensoul
+  - Perl: @wing328 [❤️](https://www.patreon.com/wing328)
+  - PHP (Guzzle): @baartosz
+  - PHP (with Data Transfer): @Articus
+  - PowerShell: @beatcracker
+  - PowerShell (refactored in 5.0.0): @wing328
+  - Python: @spacether \[:heart:\]\[spacether sponsorship\]
+  - Python-Experimental: @spacether \[:heart:\]\[spacether sponsorship\]
+  - Python (refactored in 7.0.0): @wing328
+  - R: @ramnov
+  - Ruby (Faraday): @meganemura @dkliban
+  - Ruby (HTTPX): @honeyryderchuck
+  - Rust: @farcaller
+  - Rust (rust-server): @metaswitch
+  - Scala (scalaz & http4s): @tbrown1979
+  - Scala (Akka): @cchafer
+  - Scala (sttp): @chameleon82
+  - Scala (sttp4): @flsh86
+  - Scala (Pekko): @mickaelmagniez
+  - Scala (http4s): @JennyLeahy
+  - Swift: @tkqubo
+  - Swift 3: @hexelon
+  - Swift 4: @ehyche
+  - Swift 5: @4brunu
+  - Swift 6: @4brunu
+  - Swift Combine: @dydus0x14
+  - TypeScript (Angular1): @mhardorf
+  - TypeScript (Angular2): @roni-frantchi
+  - TypeScript (Angular6): @akehir
+  - TypeScript (Angular7): @topce
+  - TypeScript (Axios): @nicokoenig
+  - TypeScript (Fetch): @leonyu
+  - TypeScript (Inversify): @gualtierim
+  - TypeScript (jQuery): @bherila
+  - TypeScript (Nestjs): @vfrank66
+  - TypeScript (Node): @mhardorf
+  - TypeScript (Rxjs): @denyo
+  - TypeScript (redux-query): @petejohansonxo
+  - Xojo: @Topheee
+  - Zapier: @valmoz, @emajo
+- Server Stubs
+  - Ada: @stcarrez
+  - C# ASP.NET 5: @jimschubert [❤️](https://www.patreon.com/jimschubert)
+  - C# ASP.NET Core 3.0: @A-Joshi
+  - C# APS.NET Core 3.1: @phatcher
+  - C# Azure functions: @Abrhm7786
+  - C# NancyFX: @mstefaniuk
+  - C++ (Qt5 QHttpEngine): @etherealjoy
+  - C++ Pistache: @sebymiano
+  - C++ Restbed: @stkrwork
+  - Erlang Server: @galaxie @nelsonvides
+  - F# (Giraffe) Server: @nmfisher
+  - Go Server: @guohuang
+  - Go Server (refactored in 7.0.0): @lwj5
+  - Go (Echo) Server: @ph4r5h4d
+  - Go (Gin) Server: @kemokemo
+  - GraphQL Express Server: @renepardon
+  - Haskell Servant: @algas
+  - Haskell Yesod: @yotsuya
+  - Java Camel: @carnevalegiacomo
+  - Java MSF4J: @sanjeewa-malalgoda
+  - Java Spring Boot: @diyfr
+  - Java Undertow: @stevehu
+  - Java Play Framework: @JFCote
+  - Java PKMST: @anshu2185 @sanshuman @rkumar-pk @ninodpillai
+  - Java Vert.x: @lwlee2608
+  - Java Micronaut: @andriy-dmytruk
+  - Java Helidon: @spericas @tjquinno @tvallin
+  - Java WireMock: [@acouvreur](https://github.com/acouvreur)
+  - JAX-RS RestEasy: @chameleon82
+  - JAX-RS CXF: @hiveship
+  - JAX-RS CXF (CDI): @nickcmaynard
+  - JAX-RS RestEasy (JBoss EAP): @jfiala
+  - Julia: @tanmaykm
+  - Kotlin: @jimschubert [❤️](https://www.patreon.com/jimschubert)
+  - Kotlin (Spring Boot): @dr4ke616
+  - Kotlin (Vertx): @Wooyme
+  - Kotlin (JAX-RS): @anttileppa
+  - Kotlin WireMock: @stefankoppier
+  - NodeJS Express: @YishTish
+  - PHP Flight: @daniel-sc
+  - PHP Laravel: @renepardon
+  - PHP Laravel (refactor in 7.12.0): @gijs-blanken
+  - PHP Lumen: @abcsun
+  - PHP Mezzio (with Path Handler): @Articus
+  - PHP Slim: @jfastnacht
+  - PHP Slim4: [@ybelenko](https://github.com/ybelenko)
+  - PHP Symfony: @ksm2
+  - PHP Symfony6: @BenjaminHae
+  - Python FastAPI: @krjakbrjak
+  - Python AIOHTTP:
+  - Ruby on Rails 5: @zlx
+  - Rust (rust-server): @metaswitch
+  - Rust (rust-axum): @linxGnu
+  - Scala Akka: @Bouillie
+  - Scala Cask: @aaronp
+  - Scala Finch: @jimschubert [❤️](https://www.patreon.com/jimschubert)
+  - Scala Lagom: @gmkumar2005
+  - Scala Play: @adigerber
+- Documentation
+  - AsciiDoc: @man-at-home
+  - HTML Doc 2: @jhitchcock
+  - Confluence Wiki: @jhitchcock
+  - PlantUML: @pburls
+- Configuration
+  - Apache2: @stkrwork
+  - k6: @mostafa
+- Schema
+  - Avro: @sgadouar
+  - GraphQL: @wing328 [❤️](https://www.patreon.com/wing328)
+  - Ktorm: @Luiz-Monad
+  - MySQL: [@ybelenko](https://github.com/ybelenko)
+  - PostgreSQL: [@iri](https://github.com/iri)
+  - Postman Collection: @gcatanese
+  - Protocol Buffer: @wing328
+  - WSDL: @adessoDpd
 
 ❤️ = Link to support the contributor directly
 
@@ -1699,12 +1710,12 @@ Here is a list of template creators:
 
 Here are the requirements to become a core team member:
 
--   rank within top 50 in [https://github.com/openapitools/openapi-generator/graphs/contributors](https://github.com/openapitools/openapi-generator/graphs/contributors)
-    -   to contribute, here are some good [starting points](https://github.com/openapitools/openapi-generator/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
--   regular contributions to the project
-    -   about 3 hours per week
-    -   for contribution, it can be addressing issues, reviewing PRs submitted by others, submitting PR to fix bugs or make enhancements, etc
-    -   must be active in the past 3 months at the time of application
+- rank within top 50 in [https://github.com/openapitools/openapi-generator/graphs/contributors](https://github.com/openapitools/openapi-generator/graphs/contributors)
+  - to contribute, here are some good [starting points](https://github.com/openapitools/openapi-generator/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
+- regular contributions to the project
+  - about 3 hours per week
+  - for contribution, it can be addressing issues, reviewing PRs submitted by others, submitting PR to fix bugs or make enhancements, etc
+  - must be active in the past 3 months at the time of application
 
 To join the core team, please reach out to [team@openapitools.org](mailto:team@openapitools.org) for more information.
 
@@ -1716,10 +1727,10 @@ To become a Template Creator, simply submit a PR for new API client (e.g. Rust, 
 
 Members of the OpenAPI Generator technical committee shoulder the following responsibilities:
 
--   Provides guidance and direction to other users
--   Reviews pull requests and issues
--   Improves the generator by making enhancements, fixing bugs or updating documentations
--   Sets the technical direction of the generator
+- Provides guidance and direction to other users
+- Reviews pull requests and issues
+- Improves the generator by making enhancements, fixing bugs or updating documentations
+- Sets the technical direction of the generator
 
 Who is eligible? Those who want to join must have at least 3 PRs merged into a generator. (Exceptions can be granted to template creators or contributors who have made a lot of code changes with less than 3 merged PRs)
 
@@ -1913,55 +1924,55 @@ OpenAPI Generator is a fork of [Swagger Codegen](https://github.com/swagger-api/
 
 [](#founding-members-alphabetical-order)
 
--   [Akihito Nakano](https://github.com/ackintosh)
--   [Artem Ocheredko](https://github.com/galaxie)
--   [Arthur Mogliev](https://github.com/Articus)
--   [Bartek Kryza](https://github.com/bkryza)
--   [Ben Wells](https://github.com/bvwells)
--   [Benjamin Gill](https://github.com/bjgill)
--   [Christophe Bornet](https://github.com/cbornet)
--   [Cliffano Subagio](https://github.com/cliffano)
--   [Daiki Matsudate](https://github.com/d-date)
--   [Daniel](https://github.com/Danielku15)
--   [Emiliano Bonassi](https://github.com/emilianobonassi)
--   [Erik Timmers](https://github.com/eriktim)
--   [Esteban Gehring](https://github.com/macjohnny)
--   [Gustavo Paz](https://github.com/gustavoapaz)
--   [Javier Velilla](https://github.com/jvelilla)
--   [Jean-François Côté](https://github.com/JFCote)
--   [Jim Schubert](https://github.com/jimschubert)
--   [Jon Schoning](https://github.com/jonschoning)
--   [Jérémie Bresson](https://github.com/jmini) [❤️](https://www.patreon.com/jmini)
--   [Jörn Ahrens](https://github.com/jayearn)
--   [Keni Steward](https://github.com/kenisteward)
--   [Marcin Stefaniuk](https://github.com/mstefaniuk)
--   [Martin Delille](https://github.com/MartinDelille)
--   [Masahiro Yamauchi](https://github.com/algas)
--   [Michele Albano](https://github.com/michelealbano)
--   [Ramzi Maalej](https://github.com/ramzimaalej)
--   [Ravindra Nikam](https://github.com/ravinikam)
--   [Ricardo Cardona](https://github.com/ricardona)
--   [Sebastian Haas](https://github.com/sebastianhaas)
--   [Sebastian Mandrean](https://github.com/mandrean)
--   [Sreenidhi Sreesha](https://github.com/sreeshas)
--   [Stefan Krismann](https://github.com/stkrwork)
--   [Stephane Carrez](https://github.com/stcarrez)
--   [Takuro Wada](https://github.com/taxpon)
--   [Tomasz Prus](https://github.com/tomplus)
--   [Tristan Sloughter](https://github.com/tsloughter)
--   [Victor Orlovsky](https://github.com/viclovsky)
--   [Victor Trakhtenberg](https://github.com/victorgit)
--   [Vlad Frolov](https://github.com/frol)
--   [Vladimir Pouzanov](https://github.com/farcaller)
--   [William Cheng](https://github.com/wing328)
--   [Xin Meng](https://github.com/xmeng1) [❤️](https://www.patreon.com/user/overview?u=16435385)
--   [Xu Hui Hui](https://github.com/xhh)
--   [antihax](https://github.com/antihax)
--   [beatcracker](https://github.com/beatcracker)
--   [daurnimator](https:/github.com/daurnimator)
--   [etherealjoy](https://github.com/etherealjoy)
--   [jfiala](https://github.com/jfiala)
--   [lukoyanov](https://github.com/lukoyanov)
+- [Akihito Nakano](https://github.com/ackintosh)
+- [Artem Ocheredko](https://github.com/galaxie)
+- [Arthur Mogliev](https://github.com/Articus)
+- [Bartek Kryza](https://github.com/bkryza)
+- [Ben Wells](https://github.com/bvwells)
+- [Benjamin Gill](https://github.com/bjgill)
+- [Christophe Bornet](https://github.com/cbornet)
+- [Cliffano Subagio](https://github.com/cliffano)
+- [Daiki Matsudate](https://github.com/d-date)
+- [Daniel](https://github.com/Danielku15)
+- [Emiliano Bonassi](https://github.com/emilianobonassi)
+- [Erik Timmers](https://github.com/eriktim)
+- [Esteban Gehring](https://github.com/macjohnny)
+- [Gustavo Paz](https://github.com/gustavoapaz)
+- [Javier Velilla](https://github.com/jvelilla)
+- [Jean-François Côté](https://github.com/JFCote)
+- [Jim Schubert](https://github.com/jimschubert)
+- [Jon Schoning](https://github.com/jonschoning)
+- [Jérémie Bresson](https://github.com/jmini) [❤️](https://www.patreon.com/jmini)
+- [Jörn Ahrens](https://github.com/jayearn)
+- [Keni Steward](https://github.com/kenisteward)
+- [Marcin Stefaniuk](https://github.com/mstefaniuk)
+- [Martin Delille](https://github.com/MartinDelille)
+- [Masahiro Yamauchi](https://github.com/algas)
+- [Michele Albano](https://github.com/michelealbano)
+- [Ramzi Maalej](https://github.com/ramzimaalej)
+- [Ravindra Nikam](https://github.com/ravinikam)
+- [Ricardo Cardona](https://github.com/ricardona)
+- [Sebastian Haas](https://github.com/sebastianhaas)
+- [Sebastian Mandrean](https://github.com/mandrean)
+- [Sreenidhi Sreesha](https://github.com/sreeshas)
+- [Stefan Krismann](https://github.com/stkrwork)
+- [Stephane Carrez](https://github.com/stcarrez)
+- [Takuro Wada](https://github.com/taxpon)
+- [Tomasz Prus](https://github.com/tomplus)
+- [Tristan Sloughter](https://github.com/tsloughter)
+- [Victor Orlovsky](https://github.com/viclovsky)
+- [Victor Trakhtenberg](https://github.com/victorgit)
+- [Vlad Frolov](https://github.com/frol)
+- [Vladimir Pouzanov](https://github.com/farcaller)
+- [William Cheng](https://github.com/wing328)
+- [Xin Meng](https://github.com/xmeng1) [❤️](https://www.patreon.com/user/overview?u=16435385)
+- [Xu Hui Hui](https://github.com/xhh)
+- [antihax](https://github.com/antihax)
+- [beatcracker](https://github.com/beatcracker)
+- [daurnimator](https:/github.com/daurnimator)
+- [etherealjoy](https://github.com/etherealjoy)
+- [jfiala](https://github.com/jfiala)
+- [lukoyanov](https://github.com/lukoyanov)
 
 ❤️ = Link to support the contributor directly
 
@@ -2027,48 +2038,46 @@ v7.12.0 released Latest
 
 Feb 28, 2025
 
-
-
 ](/OpenAPITools/openapi-generator/releases/tag/v7.12.0)
 
 [\+ 69 releases](/OpenAPITools/openapi-generator/releases)
 
 ## Sponsor this project
 
--    ![open_collective](https://github.githubassets.com/assets/open_collective-0a706523753d.svg)[opencollective.com/**openapi\_generator**](https://opencollective.com/openapi_generator)
+- ![open_collective](https://github.githubassets.com/assets/open_collective-0a706523753d.svg)[opencollective.com/**openapi_generator**](https://opencollective.com/openapi_generator)
 
 ## [Packages 0](/orgs/OpenAPITools/packages?repo_name=openapi-generator)
 
-No packages published  
+No packages published
 
 ## [Contributors 3,164](/OpenAPITools/openapi-generator/graphs/contributors)
 
--   [![@wing328](https://avatars.githubusercontent.com/u/934260?s=64&v=4)](https://github.com/wing328)
--   [![@fehguy](https://avatars.githubusercontent.com/u/249413?s=64&v=4)](https://github.com/fehguy)
--   [![@xhh](https://avatars.githubusercontent.com/u/159740?s=64&v=4)](https://github.com/xhh)
--   [![@jimschubert](https://avatars.githubusercontent.com/u/109659?s=64&v=4)](https://github.com/jimschubert)
--   [![@jmini](https://avatars.githubusercontent.com/u/1222165?s=64&v=4)](https://github.com/jmini)
--   [![@spacether](https://avatars.githubusercontent.com/u/1912028?s=64&v=4)](https://github.com/spacether)
--   [![@devhl-labs](https://avatars.githubusercontent.com/u/29644329?s=64&v=4)](https://github.com/devhl-labs)
--   [![@geekerzp](https://avatars.githubusercontent.com/u/2854886?s=64&v=4)](https://github.com/geekerzp)
--   [![@ackintosh](https://avatars.githubusercontent.com/u/1885716?s=64&v=4)](https://github.com/ackintosh)
--   [![@4brunu](https://avatars.githubusercontent.com/u/784666?s=64&v=4)](https://github.com/4brunu)
--   [![@cbornet](https://avatars.githubusercontent.com/u/11633333?s=64&v=4)](https://github.com/cbornet)
--   [![@ePaul](https://avatars.githubusercontent.com/u/645859?s=64&v=4)](https://github.com/ePaul)
--   [![@etherealjoy](https://avatars.githubusercontent.com/u/33183834?s=64&v=4)](https://github.com/etherealjoy)
--   [![@guohuang](https://avatars.githubusercontent.com/u/1863699?s=64&v=4)](https://github.com/guohuang)
+- [![@wing328](https://avatars.githubusercontent.com/u/934260?s=64&v=4)](https://github.com/wing328)
+- [![@fehguy](https://avatars.githubusercontent.com/u/249413?s=64&v=4)](https://github.com/fehguy)
+- [![@xhh](https://avatars.githubusercontent.com/u/159740?s=64&v=4)](https://github.com/xhh)
+- [![@jimschubert](https://avatars.githubusercontent.com/u/109659?s=64&v=4)](https://github.com/jimschubert)
+- [![@jmini](https://avatars.githubusercontent.com/u/1222165?s=64&v=4)](https://github.com/jmini)
+- [![@spacether](https://avatars.githubusercontent.com/u/1912028?s=64&v=4)](https://github.com/spacether)
+- [![@devhl-labs](https://avatars.githubusercontent.com/u/29644329?s=64&v=4)](https://github.com/devhl-labs)
+- [![@geekerzp](https://avatars.githubusercontent.com/u/2854886?s=64&v=4)](https://github.com/geekerzp)
+- [![@ackintosh](https://avatars.githubusercontent.com/u/1885716?s=64&v=4)](https://github.com/ackintosh)
+- [![@4brunu](https://avatars.githubusercontent.com/u/784666?s=64&v=4)](https://github.com/4brunu)
+- [![@cbornet](https://avatars.githubusercontent.com/u/11633333?s=64&v=4)](https://github.com/cbornet)
+- [![@ePaul](https://avatars.githubusercontent.com/u/645859?s=64&v=4)](https://github.com/ePaul)
+- [![@etherealjoy](https://avatars.githubusercontent.com/u/33183834?s=64&v=4)](https://github.com/etherealjoy)
+- [![@guohuang](https://avatars.githubusercontent.com/u/1863699?s=64&v=4)](https://github.com/guohuang)
 
 [\+ 3,150 contributors](/OpenAPITools/openapi-generator/graphs/contributors)
 
 ## Languages
 
--   [Java 93.0%](/OpenAPITools/openapi-generator/search?l=java)
--   [TypeScript 2.1%](/OpenAPITools/openapi-generator/search?l=typescript)
--   [Kotlin 1.3%](/OpenAPITools/openapi-generator/search?l=kotlin)
--   [Shell 1.1%](/OpenAPITools/openapi-generator/search?l=shell)
--   [Handlebars 0.5%](/OpenAPITools/openapi-generator/search?l=handlebars)
--   [JavaScript 0.3%](/OpenAPITools/openapi-generator/search?l=javascript)
--   Other 1.7%
+- [Java 93.0%](/OpenAPITools/openapi-generator/search?l=java)
+- [TypeScript 2.1%](/OpenAPITools/openapi-generator/search?l=typescript)
+- [Kotlin 1.3%](/OpenAPITools/openapi-generator/search?l=kotlin)
+- [Shell 1.1%](/OpenAPITools/openapi-generator/search?l=shell)
+- [Handlebars 0.5%](/OpenAPITools/openapi-generator/search?l=handlebars)
+- [JavaScript 0.3%](/OpenAPITools/openapi-generator/search?l=javascript)
+- Other 1.7%
 
 ## Footer
 
@@ -2076,13 +2085,13 @@ No packages published
 
 ### Footer navigation
 
--   [Terms](https://docs.github.com/site-policy/github-terms/github-terms-of-service)
--   [Privacy](https://docs.github.com/site-policy/privacy-policies/github-privacy-statement)
--   [Security](https://github.com/security)
--   [Status](https://www.githubstatus.com/)
--   [Docs](https://docs.github.com/)
--   [Contact](https://support.github.com?tags=dotcom-footer)
--   Manage cookies
--   Do not share my personal information
+- [Terms](https://docs.github.com/site-policy/github-terms/github-terms-of-service)
+- [Privacy](https://docs.github.com/site-policy/privacy-policies/github-privacy-statement)
+- [Security](https://github.com/security)
+- [Status](https://www.githubstatus.com/)
+- [Docs](https://docs.github.com/)
+- [Contact](https://support.github.com?tags=dotcom-footer)
+- Manage cookies
+- Do not share my personal information
 
 You can’t perform that action at this time.

--- a/scripts/copy-generated.js
+++ b/scripts/copy-generated.js
@@ -103,6 +103,24 @@ try {
 
 console.log("Successfully compiled OpenAPI client!");
 
+// Fix any issues in the compiled files
+console.log("Fixing potential issues in compiled files...");
+
+// Fix "Cannot access 'basePath' before initialization" error in base.js
+const baseJsPath = path.join(DIST_BAAS_DIR, "base.js");
+if (fs.existsSync(baseJsPath)) {
+  let baseContent = fs.readFileSync(baseJsPath, "utf8");
+
+  // Replace the problematic constructor
+  baseContent = baseContent.replace(
+    /constructor\(configuration, basePath = basePath, axios = axios_1.default\) {/g,
+    "constructor(configuration, basePath = '', axios = axios_1.default) {"
+  );
+
+  fs.writeFileSync(baseJsPath, baseContent);
+  console.log("- Fixed BaseAPI constructor in base.js");
+}
+
 // Create .mjs versions for ESM support by copying the .js files and updating
 // Path remapping is a safer approach than trying to parse and modify the JS files
 console.log("Creating ESM versions (.mjs)...");

--- a/scripts/post-generate.js
+++ b/scripts/post-generate.js
@@ -1,17 +1,17 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
 // Function to convert snake_case to camelCase
 function toCamelCase(str) {
-  return str.replace(/([-_][a-z])/g, group =>
-    group.toUpperCase().replace('-', '').replace('_', '')
+  return str.replace(/([-_][a-z])/g, (group) =>
+    group.toUpperCase().replace("-", "").replace("_", "")
   );
 }
 
 // Function to transform property names in an object
 function transformProperties(obj) {
-  if (typeof obj !== 'object' || obj === null) return obj;
-  
+  if (typeof obj !== "object" || obj === null) return obj;
+
   if (Array.isArray(obj)) {
     return obj.map(transformProperties);
   }
@@ -53,103 +53,116 @@ function transformSnakeToCamel(content) {
 }
 
 // Read and transform the generated API files
-const apiDir = path.join(__dirname, '../src/generated/baas/api');
-const modelDir = path.join(__dirname, '../src/generated/baas/models');
+const apiDir = path.join(__dirname, "../src/generated/baas/api");
+const modelDir = path.join(__dirname, "../src/generated/baas/models");
 const files = fs.readdirSync(apiDir);
 
 // First pass: collect all API classes
 const apiClasses = [];
-files.forEach(file => {
-  if (!file.endsWith('-api.ts')) return;
-  const className = file.replace('.ts', '').split('-').map(part => 
-    part.charAt(0).toUpperCase() + part.slice(1)
-  ).join('');
+files.forEach((file) => {
+  if (!file.endsWith("-api.ts")) return;
+  const className = file
+    .replace(".ts", "")
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("");
   apiClasses.push({
     fileName: file,
-    className: className
+    className: className,
   });
 });
 
 // Transform model files to use camelCase
 const modelFiles = fs.readdirSync(modelDir);
-modelFiles.forEach(file => {
-  if (!file.endsWith('.ts')) return;
-  
+modelFiles.forEach((file) => {
+  if (!file.endsWith(".ts")) return;
+
   const filePath = path.join(modelDir, file);
-  let content = fs.readFileSync(filePath, 'utf8');
+  let content = fs.readFileSync(filePath, "utf8");
   content = transformSnakeToCamel(content);
   fs.writeFileSync(filePath, content);
 });
 
 // Transform API files to use camelCase
-files.forEach(file => {
-  if (!file.endsWith('.ts')) return;
-  
+files.forEach((file) => {
+  if (!file.endsWith(".ts")) return;
+
   const filePath = path.join(apiDir, file);
-  let content = fs.readFileSync(filePath, 'utf8');
-  
+  let content = fs.readFileSync(filePath, "utf8");
+
   // First fix the constant names in both imports and usage
-  content = content.replace(/\bDUMMY_BASEURL\b/g, 'DUMMY_BASE_URL');
-  content = content.replace(/\bBASEPATH\b/g, 'BASE_PATH');
-  content = content.replace(/\bBASE_PATH\b/g, 'basePath');
-  
+  content = content.replace(/\bDUMMY_BASEURL\b/g, "DUMMY_BASE_URL");
+  content = content.replace(/\bBASEPATH\b/g, "BASE_PATH");
+  content = content.replace(/\bBASE_PATH\b/g, "basePath");
+
   // Fix the function return statements to ensure basePath is always a string
   content = content.replace(
     /return \(axios, basePath\) => createRequestFunction\(([^)]+)\)\(axios, localVarOperationServerBasePath \|\| basePath\)/g,
-    'return (axios, basePath = \'\') => createRequestFunction($1)(axios, localVarOperationServerBasePath || basePath)'
+    "return (axios, basePath = '') => createRequestFunction($1)(axios, localVarOperationServerBasePath || basePath)"
   );
-  
+
   // Fix parameter types to handle undefined values
   content = content.replace(
     /(?:const|let|var)\s+(\w+)\s*:\s*string\s*\|\s*undefined/g,
-    '$1?: string'
+    "$1?: string"
   );
-  
+
   // Add null checks for string parameters
   content = content.replace(
     /(\w+)\s*=\s*(\w+)\s*\|\|\s*undefined/g,
-    '$1 = $2 || \'\''
+    "$1 = $2 || ''"
   );
-  
+
   // Fix basePath parameter default value
   content = content.replace(
     /basePath: string = basePath/g,
-    'basePath: string = \'\''
+    "basePath: string = ''"
   );
-  
+
   // Then transform snake_case to camelCase in method names and parameters
   content = transformSnakeToCamel(content);
-  
+
   fs.writeFileSync(filePath, content);
 });
 
 // Also fix the constant names in base.ts and common.ts
-const baseFiles = ['base.ts', 'common.ts'];
-baseFiles.forEach(file => {
-  const filePath = path.join(__dirname, '../src/generated/baas', file);
+const baseFiles = ["base.ts", "common.ts"];
+baseFiles.forEach((file) => {
+  const filePath = path.join(__dirname, "../src/generated/baas", file);
   if (fs.existsSync(filePath)) {
-    let content = fs.readFileSync(filePath, 'utf8');
-    content = content.replace(/\bDUMMY_BASEURL\b/g, 'DUMMY_BASE_URL');
-    content = content.replace(/\bBASEPATH\b/g, 'BASE_PATH');
-    content = content.replace(/\bBASE_PATH\b/g, 'basePath');
-    
+    let content = fs.readFileSync(filePath, "utf8");
+    content = content.replace(/\bDUMMY_BASEURL\b/g, "DUMMY_BASE_URL");
+    content = content.replace(/\bBASEPATH\b/g, "BASE_PATH");
+    content = content.replace(/\bBASE_PATH\b/g, "basePath");
+
     // Fix the specific circular reference in common.ts
-    if (file === 'common.ts') {
+    if (file === "common.ts") {
       content = content.replace(
         /return <T = unknown, R = AxiosResponse<T>>\(axios: AxiosInstance = globalAxios, basePath: string = basePath\) =>/g,
-        'return <T = unknown, R = AxiosResponse<T>>(axios: AxiosInstance = globalAxios, basePath: string = \'\') =>'
+        "return <T = unknown, R = AxiosResponse<T>>(axios: AxiosInstance = globalAxios, basePath: string = '') =>"
       );
     }
-    
+
+    // Fix the BaseAPI constructor to avoid "Cannot access 'basePath' before initialization"
+    if (file === "base.ts") {
+      content = content.replace(
+        /constructor\(configuration\?: Configuration, basePath: string = basePath, axios: AxiosInstance = globalAxios\) {/g,
+        "constructor(configuration?: Configuration, basePath: string = '', axios: AxiosInstance = globalAxios) {"
+      );
+    }
+
     content = transformSnakeToCamel(content);
     fs.writeFileSync(filePath, content);
   }
 });
 
 // Generate client wrappers
-const imports = apiClasses.map(api => 
-  `import { ${api.className} } from './${api.fileName.replace('.ts', '')}';`
-).join('\n');
+const imports = apiClasses
+  .map(
+    (api) =>
+      `import { ${api.className} } from './${api.fileName.replace(".ts", "")}';`
+  )
+  .join("\n");
 
 const clientContent = `import { Configuration } from '../configuration';
 ${imports}
@@ -165,35 +178,44 @@ export interface BaasClientConfig {
  */
 export class BaasClient {
   private configuration: Configuration;
-  ${apiClasses.map(api => {
-    const instanceName = api.className.charAt(0).toLowerCase() + api.className.slice(1);
-    return `private _${instanceName}: ${api.className};`;
-  }).join('\n  ')}
+  ${apiClasses
+    .map((api) => {
+      const instanceName =
+        api.className.charAt(0).toLowerCase() + api.className.slice(1);
+      return `private _${instanceName}: ${api.className};`;
+    })
+    .join("\n  ")}
 
   constructor(config: BaasClientConfig) {
     this.configuration = new Configuration({
       apiKey: config.apiKey,
       basePath: config.baseUrl,
     });
-    ${apiClasses.map(api => {
-      const instanceName = api.className.charAt(0).toLowerCase() + api.className.slice(1);
-      return `this._${instanceName} = new ${api.className}(this.configuration);`;
-    }).join('\n    ')}
+    ${apiClasses
+      .map((api) => {
+        const instanceName =
+          api.className.charAt(0).toLowerCase() + api.className.slice(1);
+        return `this._${instanceName} = new ${api.className}(this.configuration);`;
+      })
+      .join("\n    ")}
   }
 
-  ${apiClasses.map(api => {
-    const instanceName = api.className.charAt(0).toLowerCase() + api.className.slice(1);
-    return `/**
+  ${apiClasses
+    .map((api) => {
+      const instanceName =
+        api.className.charAt(0).toLowerCase() + api.className.slice(1);
+      return `/**
    * Get the ${api.className} instance
    */
   get ${instanceName}() {
     return this._${instanceName};
   }`;
-  }).join('\n\n  ')}
+    })
+    .join("\n\n  ")}
 }
 `;
 
 // Write client file
-fs.writeFileSync(path.join(apiDir, 'client.ts'), clientContent);
+fs.writeFileSync(path.join(apiDir, "client.ts"), clientContent);
 
-console.log('Post-generation transformations completed');
+console.log("Post-generation transformations completed");

--- a/src/generated/baas/README.md
+++ b/src/generated/baas/README.md
@@ -1,25 +1,29 @@
-## @meeting-baas/sdk@4.0.3
+## @meeting-baas/sdk@4.0.4
 
 This generator creates TypeScript/JavaScript client that utilizes [axios](https://github.com/axios/axios). The generated Node module can be used in the following environments:
 
 Environment
-* Node.js
-* Webpack
-* Browserify
+
+- Node.js
+- Webpack
+- Browserify
 
 Language level
-* ES5 - you must have a Promises/A+ library installed
-* ES6
+
+- ES5 - you must have a Promises/A+ library installed
+- ES6
 
 Module system
-* CommonJS
-* ES6 module system
+
+- CommonJS
+- ES6 module system
 
 It can be used in both TypeScript and JavaScript. In TypeScript, the definition will be automatically resolved via `package.json`. ([Reference](https://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html))
 
 ### Building
 
 To build and compile the typescript sources to javascript use:
+
 ```
 npm install
 npm run build
@@ -36,7 +40,7 @@ navigate to the folder of your consuming project and run one of the following co
 _published:_
 
 ```
-npm install @meeting-baas/sdk@4.0.3 --save
+npm install @meeting-baas/sdk@4.0.4 --save
 ```
 
 _unPublished (not recommended):_

--- a/src/generated/baas/package.json
+++ b/src/generated/baas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeting-baas/sdk",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "OpenAPI client for @meeting-baas/sdk",
   "author": "OpenAPI-Generator Contributors",
   "repository": {


### PR DESCRIPTION
- Fix BaseAPI constructor in TypeScript source to avoid parameter self-reference
- Add post-processing step to fix the same issue in compiled JavaScript
- Apply fixes in both pre-compilation (post-generate.js) and post-compilation (copy-generated.js)

This resolves the runtime error that occurred when initializing API clients through the SDK. The issue was caused by a JavaScript parameter referencing itself in its own default value.