### PR TITLE
fix: use interceptor to send {} body on no-body POST/DELETE requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeting-baas/sdk",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "description": "Official SDK for Meeting BaaS API - https://meetingbaas.com",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/custom-axios.ts
+++ b/src/custom-axios.ts
@@ -2,13 +2,18 @@ import Axios, { type AxiosRequestConfig } from "axios"
 
 const AXIOS_INSTANCE = Axios.create()
 
-// Strip Content-Type when there's no request body.
-// Axios sets Content-Type: application/json by default on POST/PUT/PATCH even
-// when the body is undefined, causing Fastify to reject the request with
-// FST_ERR_CTP_EMPTY_JSON_BODY or FST_ERR_CTP_INVALID_MEDIA_TYPE.
+// For requests with no body (data is undefined/null), set data to "{}" and
+// Content-Type to application/json. This prevents Node's http module from
+// adding Content-Type: application/x-www-form-urlencoded on POST requests,
+// which Fastify rejects with FST_ERR_CTP_INVALID_MEDIA_TYPE. Fastify accepts
+// an empty JSON object {} with application/json.
+//
+// We use a request interceptor which runs after axios merges defaults but
+// before the request is dispatched.
 AXIOS_INSTANCE.interceptors.request.use((config) => {
   if (config.data === undefined || config.data === null) {
-    config.headers.delete("Content-Type")
+    config.data = "{}"
+    config.headers.setContentType("application/json")
   }
   return config
 })
@@ -19,7 +24,11 @@ export const customInstance = <T>(
 ): Promise<T> => {
   return AXIOS_INSTANCE({
     ...config,
-    ...options
+    ...options,
+    headers: {
+      ...config?.headers,
+      ...options?.headers
+    }
   }).then(({ data }) => data)
 }
 


### PR DESCRIPTION
## Summary
- Fix the custom axios instance to use a request interceptor instead of `transformRequest`
- When a request has no body (`data` is `undefined`/`null`), the interceptor sets `data` to `"{}"` with `Content-Type: application/json`, which Fastify accepts
- The previous `transformRequest` approach failed because axios re-applies `Content-Type: application/x-www-form-urlencoded` after `transformRequest` for POST requests with no body
- Bump version to 6.1.4

## Verified against real API
- `resendFinalWebhook` (POST no body): `success: true` (was 415 before)
- `deleteCalendarConnection` (DELETE no body): proper 404 (was 415 before)
- `getBotDetails` (GET): `success: true`
- `createBot` (POST with body): works correctly

## Test plan
- [x] All 214 tests pass
- [x] 100% code coverage
- [x] Manual verification against pre-prod API via `/Users/mohammadyusuf/Projects/manual-sdk-generator-test`