### PR TITLE
fix(gladia): strip deprecated keys from language_config + drop detect_language metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Dependencies
 node_modules/
 .pnpm-store/
+.claude
 
 # Generated files
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,72 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.6] - 2026-06-01
+
+### Fixed
+
+#### Speechmatics Batch File Upload Multipart Body
+
+Fixed `SpeechmaticsAdapter.transcribe()` for the file-input branch so `POST /v2/jobs` is sent as a real `multipart/form-data` body with a boundary. The previous implementation built a plain object `{ config, data_file }` and set the `Content-Type: multipart/form-data` header on the axios request; axios then serialized the object as JSON and Speechmatics rejected the request with `"Content-Type must be multipart/form-data"`, so no job was ever created (`transcription_id: null`). The adapter now constructs a `FormData` (normalizing `Buffer` to `Blob` for Node) and lets axios derive `Content-Type` with the boundary. URL input (`fetch_data`) was unaffected.
+
+## [0.9.5] - 2026-06-01
+
+### Added
+
+#### Provider Update Checker
+
+New `pnpm providers:check-updates` tool that fetches every tracked upstream — provider specs, npm SDK declaration files, remote-content URLs — and reports drift against the recorded baselines in `specs/.checksums.json`. Use `--write` to baseline. Exit code is `0` when clean, `2` when changes are detected, `1` on error — suitable for CI scheduling. Companion: `pnpm openapi:check-consumed` (exit `2` if any post-fix spec on disk differs from the recorded `consumedSha256`).
+
+#### Consumed-Spec Checksum Tracking
+
+`specs/.checksums.json` now records `consumedSha256` (and `consumedAt`, `fixedBy`) alongside the raw upstream `sha256` for every non-manual spec. The consumed checksum is the hash of the spec file *after* `fix-*-spec.js` runs — i.e. the exact bytes orval reads — so the file records both "what we downloaded from upstream" and "what codegen was built from", closing the gap for the five fixed specs (assemblyai, deepgram, openai, speechmatics, elevenlabs). `pnpm openapi:record-consumed` writes the field and is wired into `openapi:generate` immediately after `openapi:fix-specs`.
+
+#### Hand-Maintained Generated File Restores
+
+`scripts/fix-generated.js` now restores four files under `src/generated/` that have no generator and were being wiped by `openapi:clean`: `soniox/sdk-types.ts`, `soniox/streaming-response-types.ts`, `elevenlabs/streaming-response-types.ts`, and `deepgram/streaming-response-types.ts`. Canonical sources are tracked under `specs/` and registered as `manual` entries in the spec manifest with `dependsOnUpstreams` links so the checker flags them for review when the relevant SDK changes.
+
+#### Shared Spec Manifest
+
+Extracted `SPEC_SOURCES` and `PROVIDERS` definitions into `scripts/provider-upstream-manifest.js`, shared by `sync-specs.js` and the new checker. Also exports `canonicalizeForHash` and `stableStringify`.
+
+### Changed
+
+#### ElevenLabs Language List (public API change)
+
+`ElevenLabsLanguageCodes`, `ElevenLabsLanguages`, `ElevenLabsLanguageLabels`, and `ElevenLabsLanguage` now contain **80 entries** (was 99). ElevenLabs removed 19 languages from Scribe coverage: `la`, `mi`, `br`, `eu`, `sq`, `si`, `yi`, `fo`, `ht`, `tk`, `sa`, `bo`, `tl`, `mg`, `tt`, `haw`, `ba`, `su`, `nn`. The curated list now lives in tracked `specs/elevenlabs-languages.json` instead of being inlined in the generator script.
+
+#### Upstream Specs Synced + Regenerated
+
+All eight upstream specs were re-synced and the full provider type set regenerated. Notable: OpenAI realtime model union now includes the latest `gpt-realtime-2`, `gpt-realtime-mini-*`, `gpt-audio-1.5`, `gpt-audio-mini-*` variants; new schema files for transcript metadata (AssemblyAI), reasoning (OpenAI), usage logs and TTS (Soniox), and audio-filtering / speaker-input (Speechmatics).
+
+#### Soniox Generate Step Ordering
+
+`openapi:generate` and `openapi:generate:soniox` now run `sync-soniox-models` before `sync-soniox-streaming`. The streaming generator reads from `src/generated/soniox/models.ts` to enrich realtime model metadata, and the previous order caused `ENOENT` on a from-scratch rebuild.
+
+### Fixed
+
+#### Canonical Hashing for Non-Deterministic Upstreams
+
+Spec hashing now canonicalizes JSON content (parse + stable-key stringify) and masks ISO-8601 timestamps before producing the SHA. Without this, providers that reorder keys per request or embed the current server time in `example` fields (e.g. Gladia) reported a "changed" spec on every check, drowning real upstream signal.
+
+#### Relative Redirect Handling
+
+`sync-specs.js` and `check-provider-updates.js` now resolve relative `Location` headers against the request URL via `new URL(location, requestUrl)`, drain the redirect body, and cap at 10 hops. The prior code passed the raw `Location` value into `http.get()`, which threw `Invalid URL` and crashed the script on the first relative redirect (e.g. ElevenLabs docs).
+
+#### NPM Tarball Declaration File Lookup
+
+`normalizeTarPath` now strips a leading `./` so declaration paths resolved from `package.json` `exports.types` (`./dist/index.d.cts`) match tarball entries (`package/dist/index.d.cts`). Previously every SDK declaration hash silently failed with `File not found in npm tarball: ./dist/...`, defeating SDK-drift detection.
+
+#### sync-specs Preserves Consumed Fields
+
+`sync-specs.js` now spreads the existing checksums entry when rewriting it, so `consumedSha256` / `consumedAt` / `fixedBy` survive a re-sync. Previously they were silently wiped each time.
+
+### Internal
+
+#### Dropped Noisy Upstream
+
+Removed `deepgramModelsApi` from `providerUpstreams`. Its `/v1/models` response carries per-request fields that vary even after JSON canonicalization, so any baseline would report drift every run. Real Deepgram changes are still surfaced via the `@deepgram/sdk` npm baseline and the `deepgram-openapi.yml` spec.
+
 ## [0.9.4] - 2026-04-28
 
 ### Changed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,385 @@
+# Architecture: Options Surfacing & Adapters
+
+> Reference for agents and contributors editing this repo. Pairs with
+> [`sdk-generation-pipeline.mmd`](./sdk-generation-pipeline.mmd) (the visual
+> dataflow) and [`package.json`](../package.json) (the script wiring).
+
+The SDK exposes a single `VoiceRouter.transcribe(audio, options)` entry point
+that targets 8 transcription providers. The trick is that `options` is at once
+**provider-agnostic** (unified fields like `language`, `diarization`) and
+**fully typed per provider** (`gladia: { translation: true, ... }` autocompletes
+against Gladia's generated OpenAPI types). This document explains how that
+shape is built and how to add or modify it.
+
+---
+
+## 1. The pipeline (one paragraph)
+
+Upstream provider specs (OpenAPI JSON/YAML, streaming SDK `.ts` files, HTML
+docs pages, npm declaration files) are downloaded by **`sync-specs.js`** into
+`specs/`. Five of them are then transformed in place by **`fix-*-spec.js`**
+(post-fix bytes recorded as `consumedSha256`). **Orval** generates
+`src/generated/<provider>/{api,schema}` from each spec; supplementary
+generators emit language/model constants and streaming response types. Hand-
+maintained files under `src/generated/` are restored from `specs/` by
+**`fix-generated.js`** after `openapi:clean`. Adapters in `src/adapters/`
+import the generated types and the `BaseAdapter` contract to expose a unified
+API to the router. See the .mmd diagram for the visual flow; the canonical
+manifest is `scripts/provider-upstream-manifest.js`.
+
+Drift detection: `pnpm providers:check-updates` re-fetches every tracked
+source and compares against `specs/.checksums.json` (canonical JSON hashes
++ post-fix `consumedSha256` + SDK declaration hashes).
+
+---
+
+## 2. Three layers of options
+
+Defined in [`src/router/types.ts`](../src/router/types.ts).
+
+### 2.1 Unified `TranscribeOptions` (line ~394)
+
+Provider-agnostic fields: `language`, `model`, `diarization`,
+`wordTimestamps`, `interimResults`, `summarization`, `webhookUrl`, etc. These
+work for every adapter. The router selects an adapter (`selectionStrategy`),
+the adapter maps these to provider-native field names.
+
+```ts
+await router.transcribe(audio, { language: "en", diarization: true })
+```
+
+### 2.2 Provider-specific overrides
+
+A property per provider, typed against the generated request-body schema:
+
+```ts
+deepgram?:    Partial<ListenTranscribeParams>        // from generated/deepgram/schema/listenTranscribeParams
+assemblyai?:  Partial<AssemblyAITranscriptParams>    // from generated/assemblyai/schema/transcriptParams
+gladia?:      Partial<InitTranscriptionRequest>      // from generated/gladia/schema/initTranscriptionRequest
+openai?:      Partial<Omit<CreateTranscriptionRequest, "file" | "model">>
+elevenlabs?:  Partial<Omit<BodySpeechToTextV1SpeechToTextPost, "file" | "model_id" | ...>>
+soniox?:      SonioxBatchOptions
+```
+
+These give consumers the full provider API surface with IntelliSense — every
+field is typed against the spec orval just generated. **The `Partial<X>` type
+is the contract**: changing the spec changes the consumer-visible options.
+
+```ts
+await router.transcribe(audio, {
+  provider: "gladia",
+  language: "en",
+  gladia: {
+    translation: true,
+    translation_config: { target_languages: ["fr", "es"] }, // typed
+    chapterization: true
+  }
+})
+```
+
+### 2.3 Streaming-specific (`StreamingOptions` line ~1034)
+
+Extends `TranscribeOptions` (minus `webhookUrl`) and adds session-only fields
+(`encoding`, `sampleRate`, `interimResults`) plus provider-specific streaming
+keys: `gladiaStreaming`, `deepgramStreaming`, `assemblyaiStreaming`,
+`speechmaticsStreaming`, `sonioxStreaming`, `elevenlabsStreaming`,
+`openaiStreaming`. Same `Partial<>` pattern, typed against the streaming
+request schemas.
+
+### 2.4 Extended response data (the inverse)
+
+`ProviderExtendedDataMap` (line ~289) ties each provider to its rich
+extended payload type (`GladiaExtendedData`, `AssemblyAIExtendedData`, etc.).
+A response typed `UnifiedTranscriptResponse<"gladia">` carries
+`extended: GladiaExtendedData` with full per-provider typing on the way back
+out.
+
+---
+
+## 3. How options flow at runtime
+
+```
+consumer ──→ router.transcribe(audio, options)
+              │
+              │  selectionStrategy: explicit | default | round-robin
+              ▼
+            adapter.transcribe(audio, options)
+              │
+              │  1. Validate config (api key, etc.)
+              │  2. Build provider-native body:
+              │     a. Map unified fields  (options.language → provider key)
+              │     b. Spread provider-specific overrides last
+              │        ({ ...mappedFromUnified, ...options.gladia })
+              │     c. Apply defaults (punctuate, smart_format, etc.)
+              │  3. Send HTTP via axios (URL branch JSON or file branch FormData)
+              │  4. Parse provider response
+              ▼
+            adapter.normalize* (helpers in src/utils/transcription-helpers.ts)
+              │
+              │  Build UnifiedTranscriptResponse.data:
+              │   text, words[], utterances[], speakers[], confidence, ...
+              │  Populate .extended with provider-specific payload (typed)
+              │  Populate .raw with the full provider response (typed)
+              ▼
+            UnifiedTranscriptResponse<P>
+```
+
+Two principles:
+- **Provider-specific overrides win.** Adapters spread `options.<provider>`
+  last so the consumer can always override what the unified mapping decided.
+- **Generated types are the contract.** Adapters never invent options shapes;
+  they pass through `Partial<GeneratedRequestType>`.
+
+Example (Deepgram, `src/adapters/deepgram-adapter.ts:475-481`):
+
+```ts
+const params: ListenTranscribeParams = {
+  ...mappedFromUnified,
+  ...options.deepgram,                                  // consumer overrides
+  punctuate:    options.deepgram?.punctuate    ?? true, // defaults last
+  utterances:   options.deepgram?.utterances   ?? true,
+  smart_format: options.deepgram?.smart_format ?? true
+}
+```
+
+---
+
+## 4. The adapter contract (`BaseAdapter`)
+
+[`src/adapters/base-adapter.ts`](../src/adapters/base-adapter.ts)
+
+```ts
+abstract class BaseAdapter implements TranscriptionAdapter {
+  readonly name: TranscriptionProvider           // "gladia" | "deepgram" | …
+  readonly capabilities: ProviderCapabilities    // { streaming, diarization, ... }
+
+  initialize(config: ProviderConfig): void       // store apiKey, build axios client
+
+  // Required
+  abstract transcribe(audio, options?): Promise<UnifiedTranscriptResponse>
+  abstract getTranscript(id): Promise<UnifiedTranscriptResponse>
+
+  // Optional
+  transcribeStream?(options, callbacks): Promise<StreamingSession>
+  transcribeStreamIterator?(options): AsyncIterable<StreamEvent>
+  deleteTranscript?(id): Promise<{ success: boolean }>
+  listTranscripts?(opts?: ListTranscriptsOptions): Promise<{...}>
+  getRawClient?(): unknown
+}
+```
+
+`ProviderCapabilities` is a flat record of `boolean` flags
+(`streaming`, `diarization`, `wordTimestamps`, `customVocabulary`,
+`summarization`, `sentimentAnalysis`, `entityDetection`, `piiRedaction`,
+`listTranscripts`, `deleteTranscript`). It's used both for routing
+decisions and for compile-time-derived types (`StreamingProvider` is
+narrowed from this map at compile time via
+`src/provider-metadata.ts`).
+
+---
+
+## 5. Writing a new adapter
+
+The order matters because each step's output feeds the next.
+
+1. **Add the spec** to `scripts/provider-upstream-manifest.js`:
+   ```js
+   const SPEC_SOURCES = {
+     // ...
+     <provider>: {
+       url: "https://…/openapi.json",
+       output: "specs/<provider>-openapi.json",
+       format: "json",
+       fixedBy: "fix-<provider>-spec.js"   // only if you need a transform
+     },
+   }
+   const PROVIDERS = {
+     // ...
+     <provider>: {
+       specKeys: ["<provider>"],
+       upstreams: [
+         { key: "<provider>NodeSdk", type: "npm-package", packageName: "…" }
+       ]
+     },
+   }
+   ```
+
+2. **Register with orval** in [`orval.config.ts`](../orval.config.ts):
+   ```ts
+   const X_INPUT = { target: "./specs/<provider>-openapi.json" }
+   export default defineConfig({
+     <provider>Api: { input: X_INPUT, output: { target: "./src/generated/<provider>/api", client: "axios-functions", mode: "single", ... } },
+     <provider>Zod: { input: X_INPUT, output: { target: "./src/generated/<provider>/api", client: "zod", fileExtension: ".zod.ts", ... } },
+   })
+   ```
+
+3. **Generate**: `pnpm openapi:sync && pnpm openapi:generate:<provider>` (per-
+   provider variant) or `pnpm openapi:rebuild` (full pipeline). Confirm
+   `src/generated/<provider>/{api,schema}` is populated.
+
+4. **Add the unified-option type slots** to `TranscribeOptions` (and
+   `StreamingOptions` if applicable) in `src/router/types.ts`:
+   ```ts
+   import type { <ProviderRequestType> } from "../generated/<provider>/schema/…"
+   export interface TranscribeOptions {
+     // ...
+     <provider>?: Partial<<ProviderRequestType>>
+   }
+   ```
+   Also add the provider key to `ProviderExtendedDataMap` (use
+   `Record<string, never>` if there's no extended data).
+
+5. **Write the adapter** under `src/adapters/<provider>-adapter.ts`:
+   ```ts
+   export class <Provider>Adapter extends BaseAdapter {
+     readonly name = "<provider>" as const
+     readonly capabilities: ProviderCapabilities = { streaming: …, … }
+     private client?: AxiosInstance
+
+     initialize(config: ProviderConfig) {
+       super.initialize(config)
+       this.client = axios.create({ baseURL: …, headers: { Authorization: `Bearer ${config.apiKey}` } })
+     }
+
+     async transcribe(audio, options) {
+       const params = {
+         ...mapUnifiedToProvider(options),
+         ...options?.<provider>     // provider overrides last
+       }
+       const response = await this.client!.post(...)
+       return {
+         success: true,
+         provider: this.name,
+         data: { id, text, words, utterances, speakers, ... },  // normalized
+         extended: { ... },                                     // typed extra
+         raw: response.data                                     // full typed
+       }
+     }
+
+     async getTranscript(id) { /* poll endpoint, normalize */ }
+   }
+   ```
+
+6. **Add helpers** if the provider returns segmented results that need
+   stitching into `words`/`utterances`/`text`. Put them in
+   [`src/utils/transcription-helpers.ts`](../src/utils/transcription-helpers.ts).
+
+7. **Webhooks** (if applicable): add `src/webhooks/<provider>-webhook.ts`
+   implementing detection + normalization, then register it in
+   `src/webhooks/webhook-router.ts`.
+
+8. **Streaming** (if applicable): if there's no streaming protocol in the
+   OpenAPI spec, hand-extract types into
+   `specs/<provider>-streaming-response-types.ts`, add a `manual: true`
+   entry to `SPEC_SOURCES` with `dependsOnUpstreams: ["<provider>SdkPackage"]`,
+   and add a restore function in `scripts/fix-generated.js` so
+   `openapi:clean` doesn't wipe it. Implement `transcribeStream` on the
+   adapter using `ws`.
+
+9. **Provider metadata**: add a `ProviderCapabilitiesMap` entry in
+   `src/provider-metadata.ts` so derived types (`StreamingProvider`,
+   `BatchOnlyProvider`) include the new provider.
+
+10. **Register** the adapter in `src/adapters/index.ts` and the router's
+    default factory in `src/router/voice-router.ts`.
+
+11. **Verify**:
+    - `pnpm openapi:check-consumed` (post-fix hash recorded)
+    - `pnpm providers:check-updates` (provider appears in output)
+    - `pnpm build` (typecheck + bundle)
+
+---
+
+## 6. Hand-maintained files under `src/generated/`
+
+`openapi:clean` wipes `src/generated/`. Files that aren't produced by orval
+or a generator must be restored, or they'll vanish on the next clean rebuild.
+
+The restore pattern (see `scripts/fix-generated.js`):
+
+1. Keep the canonical source under `specs/<provider>-<name>.ts`.
+2. Register as a `manual: true` `SPEC_SOURCE` with `dependsOnUpstreams`
+   pointing at the SDK it was extracted from.
+3. Add a `restore<Provider><What>()` function in `fix-generated.js` that
+   `fs.copyFileSync` from `specs/` to `src/generated/<provider>/<name>.ts`.
+4. Call it from `main()`.
+
+Currently restored: `speechmatics/batch-types.zod.ts`,
+`openai/streaming-types.ts`, `deepgram/{streaming-response-types,
+schema/speakV1*Parameter}`, `soniox/{sdk-types, streaming-response-types}`,
+`elevenlabs/streaming-response-types`. Also: the curated language list
+`specs/elevenlabs-languages.json` is consumed by
+`scripts/generate-elevenlabs-languages.js` to produce
+`src/generated/elevenlabs/languages.ts`.
+
+---
+
+## 7. The script wiring (cheat sheet)
+
+From [`package.json`](../package.json):
+
+| Phase | Script | What it does |
+|---|---|---|
+| Sync | `openapi:sync` | Download all 8 specs → `specs/` (uses manifest) |
+| Pre-orval fix | `openapi:fix-specs` | Run all 5 `fix-*-spec.js` in place |
+| Consumed baseline | `openapi:record-consumed` | Hash post-fix specs → `.checksums.json` |
+| Clean | `openapi:clean` | `rm -rf src/generated` |
+| Codegen | `orval` | Generate `api/` + `schema/` for all 8 providers |
+| Streaming | `openapi:sync-*-streaming` | 4 streaming-type generators |
+| Lang/model | `openapi:sync-*-languages`, `…-models` | 9 generators feeding `src/generated/<P>/{languages,models}.ts` |
+| Post-orval fix | `openapi:fix` | `fix-generated.js` (touch-ups + restore hand-maintained) |
+| All of the above | `openapi:generate` | Chained, this order, idempotent |
+| Sync + generate + build | `openapi:rebuild` | Top-level "from scratch" |
+| Drift check | `providers:check-updates` | Reports upstream + consumed drift, exit 2 = changes |
+
+The `prebuild` hook runs `fix-specs + fix + lang/model generators` only — no
+orval, no clean. That's the lightweight "produce a build artifact from
+already-generated code" path. `prepublishOnly` runs the heavy
+`sync + validate + lint:fix + build`.
+
+---
+
+## 8. Common pitfalls (lessons from past breakage)
+
+- **Multipart file uploads need real `FormData`**. Setting `Content-Type:
+  multipart/form-data` on a plain object makes axios serialize as JSON without
+  a boundary; the provider rejects. Always build a `FormData` and let axios
+  derive the header. See `speechmatics-adapter.ts:340` for the pattern.
+- **Buffer vs Blob.** `AudioInput.file` is `Buffer | Blob`. When pushing into
+  FormData in Node, wrap `Buffer` with `new Blob([buffer])` first.
+- **`openapi:clean` wipes hand-maintained files.** If you add a file under
+  `src/generated/<provider>/` that no generator emits, also add a restore
+  function in `fix-generated.js` (Section 6).
+- **`fix-*-spec.js` are not all idempotent.** Re-running on already-fixed
+  bytes can corrupt. The pipeline always runs `sync` (which re-writes raw)
+  before `fix-specs`. Don't run `fix-specs` standalone on a "clean" repo
+  expecting the same output.
+- **Non-deterministic upstreams.** Some specs reorder keys or embed
+  timestamps per request (Gladia). The checker canonicalizes JSON and masks
+  ISO-8601 timestamps. If you add a new upstream that's noisy in a different
+  way, extend `canonicalizeForHash` in
+  `scripts/provider-upstream-manifest.js`.
+- **Generated step ordering.** If a generator reads another generator's
+  output, sequence them. Example: `sync-soniox-streaming` reads
+  `src/generated/soniox/models.ts` and must run after `sync-soniox-models`.
+- **Per-provider `openapi:generate:<X>` scripts do not run
+  `record-consumed`.** Only the top-level `openapi:generate` does. After
+  per-provider regens, run `pnpm openapi:record-consumed` explicitly.
+
+---
+
+## 9. Where to start when modifying things
+
+- Adding a new option to a provider → edit upstream spec or wait for it;
+  re-sync; re-generate; the option appears automatically in the
+  `Partial<>` for that provider in `TranscribeOptions`.
+- Adding a unified field (works for every provider) → add to
+  `TranscribeOptions`, then map it inside each adapter's `transcribe`.
+- Adding a new provider → Section 5.
+- Investigating "where does this typed field come from?" → trace the import
+  in `src/router/types.ts` to its `src/generated/<P>/schema/…` file → that
+  was produced by orval from `specs/<P>-openapi.{json,yml,yaml}` per
+  `orval.config.ts`.
+- Investigating "did upstream change?" → `pnpm providers:check-updates`.
+- Investigating "is my generated code stale?" → `pnpm
+  openapi:check-consumed`.

--- a/src/adapters/gladia-adapter.ts
+++ b/src/adapters/gladia-adapter.ts
@@ -439,6 +439,26 @@ export class GladiaAdapter extends BaseAdapter {
       }
     }
 
+    // Sanitize language_config to Gladia v2's accepted shape.
+    // Gladia's language_config only accepts `languages` and `code_switching`.
+    // Deprecated/legacy keys (notably `detect_language`, replaced by
+    // `language_config`) are rejected with HTTP 400 "Invalid parameter(s)".
+    // Because `options.gladia` is spread verbatim above, a caller-supplied
+    // language_config can carry such a key straight through to Gladia. Strip
+    // it here so the passthrough can never leak an unsupported field — this
+    // restores the silent unknown-key drop the previous schema validation gave us.
+    if (request.language_config) {
+      const { languages, code_switching } = request.language_config
+      const sanitized: NonNullable<InitTranscriptionRequest["language_config"]> = {}
+      if (languages !== undefined) sanitized.languages = languages
+      if (code_switching !== undefined) sanitized.code_switching = code_switching
+      if (Object.keys(sanitized).length > 0) {
+        request.language_config = sanitized
+      } else {
+        delete request.language_config
+      }
+    }
+
     return request
   }
 

--- a/src/field-equivalences.ts
+++ b/src/field-equivalences.ts
@@ -131,7 +131,7 @@ export const FIELD_EQUIVALENCES: Record<FieldCategory, CategoryMetadata> = {
     description: "Primary transcription language or language detection",
     providers: {
       gladia: {
-        transcription: ["detect_language","language","language_config"] as const,
+        transcription: ["language","language_config"] as const,
         streaming: ["language_config"] as const
       },
       deepgram: {

--- a/src/field-metadata.ts
+++ b/src/field-metadata.ts
@@ -57,7 +57,7 @@ export interface FieldMetadata {
 // Gladia
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** Gladia transcription field metadata (35 fields) */
+/** Gladia transcription field metadata (34 fields) */
 export const GLADIA_TRANSCRIPTION_FIELDS = [
   {
     name: "context_prompt",
@@ -96,14 +96,6 @@ export const GLADIA_TRANSCRIPTION_FIELDS = [
         max: 1
       }
     ]
-  },
-  {
-    name: "detect_language",
-    type: "boolean",
-    required: true,
-    description:
-      "**[Deprecated]** Use `language_config` instead. Detect the language from the given audio",
-    default: true
   },
   {
     name: "enable_code_switching",


### PR DESCRIPTION
## Problem

Transcription submissions for some clients started failing today with Gladia `HTTP 400 "Invalid parameter(s)"`. Root cause: their config nests a deprecated field inside `language_config`:

```json
"language_config": { "languages": ["ja"], "detect_language": false }
```

Gladia v2's `language_config` only accepts **`languages`** and **`code_switching`**. `detect_language` was superseded by `language_config` and is now rejected outright — so Gladia 400s the entire submission. The recording itself succeeds; only the transcription submit fails.

## Why now

Previously, custom params were validated against the Gladia schema with Zod `safeParse`, which **silently strips unknown keys**. That dropped `detect_language` before it ever reached Gladia (and before it was persisted — which is why it had zero occurrences in the DB before today). The new transcription path forwards the **raw** params, so the deprecated field now leaks straight through to Gladia.

Blast radius is small and contained: only **2 teams / 7 bots**, all first seen today. Every other custom param in use across the fleet is a valid Gladia field, so no other integrations are affected.

## Changes

1. **`gladia-adapter.ts` — sanitize `language_config` before returning.**
   `buildTranscriptionRequest` spreads `...options.gladia` verbatim (the one place a caller-supplied `language_config` reaches Gladia), then now narrows `request.language_config` to `{languages, code_switching}` and drops it if empty. This restores the old silent-drop behavior for the field that actually 400s — no client action needed, fixes both teams immediately.

2. **Remove deprecated `detect_language` from Gladia metadata.**
   Dropped from `GLADIA_TRANSCRIPTION_FIELDS` (`field-metadata.ts`) and from the gladia transcription list in `field-equivalences.ts`, so the SDK stops advertising it as a valid Gladia field. **Deepgram's `detect_language` (a genuine Deepgram param) is untouched.**

## Notes / follow-ups
- The generated Gladia schema (`initTranscriptionRequest.ts` → `LanguageConfig`) was already correct (`languages` + `code_switching` only); the mismatch was in the hand-maintained metadata. No regeneration needed.
- Two sibling deprecated Gladia fields remain in `field-metadata.ts` (`enable_code_switching`, `code_switching_config`). They are unused fleet-wide, so left out of this hotfix — can be removed as cleanup if desired.
- The 7 affected bots recorded fine and can be re-transcribed with the corrected param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)