### PR TITLE
fix(ci): bump pnpm to 10.34.5 for npm trusted publishing

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -170,6 +170,8 @@ jobs:
     if: needs.check-and-update.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     needs: [check-and-update, bump-version-and-publish]
+    permissions:
+      contents: write # Required to create the GitHub release
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -86,5 +86,5 @@
     "axios": "1.18.0",
     "zod": "3.24.2"
   },
-  "packageManager": "pnpm@10.8.1+sha512.c50088ba998c67b8ca8c99df8a5e02fd2ae2e2b29aaf238feaa9e124248d3f48f9fb6db2424949ff901cffbb5e0f0cc1ad6aedb602cd29450751d11c35023677"
+  "packageManager": "pnpm@10.34.5+sha512.a4ee05f2f73658255bd6a89859c065a45c28a57daefae2c893a168ee2b73168c37b91e83e57ea67654ad03f03031746430e8bce38e362e042605fb8abc80192e"
 }


### PR DESCRIPTION
The auto-update workflow's publish step has failed since the switch to npm trusted publishing (OIDC): the pinned `pnpm@10.8.1` predates OIDC support, which landed in pnpm 10.13. Publishing therefore failed with an auth error, the workflow was disabled manually on Feb 24, and the SDK has drifted behind the live API since 6.2.0 (June 18) — notably the entire `/v2/teams-logins` / `/v2/teams-workspaces` surface is missing.

Changes:
- Bump `packageManager` to `pnpm@10.34.5` (hash = sha512 of the npm tarball) so `pnpm publish` can mint the OIDC token in CI.
- Add `contents: write` to the `create-release` job so the GitHub release step can create tags/releases under default read-only workflow permissions.

After merge the auto-update workflow will be re-enabled and dispatched; first run should regenerate the SDK against the live specs and publish 6.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)