### PR TITLE
feat: wire v2 teams workspaces and teams logins

### DIFF
--- a/API-REFERENCE-V2.md
+++ b/API-REFERENCE-V2.md
@@ -267,3 +267,28 @@ Manage individual Google Workspace user identities attached to a meet workspace.
 | `getMeetLogin` | Get a meet login | [`{ credential_id: string }`](https://docs.meetingbaas.com/api-v2/reference/meet-logins/getMeetLogin) |
 | `updateMeetLogin` | Rename, change `email_group`, or re-enable a login | [`{ credential_id: string; body: UpdateMeetLoginBody }`](https://docs.meetingbaas.com/api-v2/reference/meet-logins/updateMeetLogin) |
 | `deleteMeetLogin` | Delete a meet login | [`{ credential_id: string }`](https://docs.meetingbaas.com/api-v2/reference/meet-logins/deleteMeetLogin) |
+
+### Teams Workspace Management
+
+Manage Microsoft 365 tenants used for authenticated Teams bots. A teams workspace represents one tenant (identified by its primary domain) and is the parent of one or more `teams_logins`.
+
+| Method | Description | Parameters |
+| ------ | ----------- | ---------- |
+| `createTeamsWorkspace` | Create a teams workspace for a Microsoft 365 tenant | [`CreateTeamsWorkspaceBody`](https://docs.meetingbaas.com/api-v2/reference/teams-workspaces/createTeamsWorkspace) |
+| `listTeamsWorkspaces` | List teams workspaces | [`ListTeamsWorkspacesParams?`](https://docs.meetingbaas.com/api-v2/reference/teams-workspaces/listTeamsWorkspaces) |
+| `getTeamsWorkspace` | Get a teams workspace | [`{ workspace_id: string }`](https://docs.meetingbaas.com/api-v2/reference/teams-workspaces/getTeamsWorkspace) |
+| `updateTeamsWorkspace` | Rename or re-enable a workspace | [`{ workspace_id: string; body: UpdateTeamsWorkspaceBody }`](https://docs.meetingbaas.com/api-v2/reference/teams-workspaces/updateTeamsWorkspace) |
+| `deleteTeamsWorkspace` | Delete a teams workspace (cascades to its logins) | [`{ workspace_id: string }`](https://docs.meetingbaas.com/api-v2/reference/teams-workspaces/deleteTeamsWorkspace) |
+
+### Teams Login Management
+
+Manage individual Microsoft 365 accounts attached to a teams workspace. Passwords are write-only (encrypted at rest, never returned). Logins sharing the same `email_group` form one round-robin pool.
+
+| Method | Description | Parameters |
+| ------ | ----------- | ---------- |
+| `createTeamsLogin` | Create a teams login under a workspace | [`CreateTeamsLoginBody`](https://docs.meetingbaas.com/api-v2/reference/teams-logins/createTeamsLogin) |
+| `listTeamsLogins` | List teams logins across all workspaces | [`ListTeamsLoginsParams?`](https://docs.meetingbaas.com/api-v2/reference/teams-logins/listTeamsLogins) |
+| `getTeamsLoginUtilization` | Get aggregate concurrency metrics for the login pool | _no params_ — [docs](https://docs.meetingbaas.com/api-v2/reference/teams-logins/getTeamsLoginUtilization) |
+| `getTeamsLogin` | Get a teams login | [`{ credential_id: string }`](https://docs.meetingbaas.com/api-v2/reference/teams-logins/getTeamsLogin) |
+| `updateTeamsLogin` | Rename, change password/`email_group`, or re-enable a login | [`{ credential_id: string; body: UpdateTeamsLoginBody }`](https://docs.meetingbaas.com/api-v2/reference/teams-logins/updateTeamsLogin) |
+| `deleteTeamsLogin` | Delete a teams login | [`{ credential_id: string }`](https://docs.meetingbaas.com/api-v2/reference/teams-logins/deleteTeamsLogin) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeting-baas/sdk",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "Official SDK for Meeting BaaS API - https://meetingbaas.com",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/node/types.d.ts
+++ b/src/node/types.d.ts
@@ -48,6 +48,10 @@ import type {
   CreateMeetWorkspaceBody,
   CreateScheduledBotRequestBodyInput,
   CreateScheduledBotResponseData,
+  CreateTeamsLogin201Data,
+  CreateTeamsLoginBody,
+  CreateTeamsWorkspace201Data,
+  CreateTeamsWorkspaceBody,
   CreateZoomCredential201Data,
   CreateZoomCredentialBody,
   DeleteBotDataResponseData,
@@ -57,6 +61,8 @@ import type {
   DeleteMeetLogin200Data,
   DeleteMeetWorkspace200Data,
   DeleteScheduledBotResponseData,
+  DeleteTeamsLogin200Data,
+  DeleteTeamsWorkspace200Data,
   DeleteZoomCredential200Data,
   GetBotDetailsResponseData,
   GetBotStatusResponseData,
@@ -66,6 +72,9 @@ import type {
   GetMeetLoginUtilization200Data,
   GetMeetWorkspace200Data,
   GetScheduledBotResponseData,
+  GetTeamsLogin200Data,
+  GetTeamsLoginUtilization200Data,
+  GetTeamsWorkspace200Data,
   GetZoomCredential200Data,
   LeaveBotResponseData,
   ListBotsParams,
@@ -79,6 +88,10 @@ import type {
   ListRawCalendarsRequestBodyInput,
   ListRawCalendarsResponseDataItem,
   ListScheduledBotsParams,
+  ListTeamsLogins200DataItem,
+  ListTeamsLoginsParams,
+  ListTeamsWorkspaces200DataItem,
+  ListTeamsWorkspacesParams,
   ListZoomCredentials200DataItem,
   ListZoomCredentialsParams,
   ResendFinalWebhookResponseData,
@@ -101,6 +114,10 @@ import type {
   UpdateMeetWorkspaceBody,
   UpdateScheduledBotRequestBodyInput,
   UpdateScheduledBotResponseData,
+  UpdateTeamsLogin200Data,
+  UpdateTeamsLoginBody,
+  UpdateTeamsWorkspace200Data,
+  UpdateTeamsWorkspaceBody,
   UpdateZoomCredential200Data,
   PauseBotRecording200Data,
   PauseBotRecordingBody,
@@ -360,6 +377,35 @@ export interface BaasClientV2Methods {
     body: UpdateMeetLoginBody
   }): Promise<ApiResponseV2<UpdateMeetLogin200Data>>
   deleteMeetLogin(params: { credential_id: string }): Promise<ApiResponseV2<DeleteMeetLogin200Data>>
+  createTeamsWorkspace(
+    params: CreateTeamsWorkspaceBody
+  ): Promise<ApiResponseV2<CreateTeamsWorkspace201Data>>
+  listTeamsWorkspaces(
+    params?: ListTeamsWorkspacesParams
+  ): Promise<ApiResponseV2<ListTeamsWorkspaces200DataItem[]>>
+  getTeamsWorkspace(params: {
+    workspace_id: string
+  }): Promise<ApiResponseV2<GetTeamsWorkspace200Data>>
+  updateTeamsWorkspace(params: {
+    workspace_id: string
+    body: UpdateTeamsWorkspaceBody
+  }): Promise<ApiResponseV2<UpdateTeamsWorkspace200Data>>
+  deleteTeamsWorkspace(params: {
+    workspace_id: string
+  }): Promise<ApiResponseV2<DeleteTeamsWorkspace200Data>>
+  createTeamsLogin(params: CreateTeamsLoginBody): Promise<ApiResponseV2<CreateTeamsLogin201Data>>
+  listTeamsLogins(
+    params?: ListTeamsLoginsParams
+  ): Promise<ApiResponseV2<ListTeamsLogins200DataItem[]>>
+  getTeamsLoginUtilization(): Promise<ApiResponseV2<GetTeamsLoginUtilization200Data>>
+  getTeamsLogin(params: { credential_id: string }): Promise<ApiResponseV2<GetTeamsLogin200Data>>
+  updateTeamsLogin(params: {
+    credential_id: string
+    body: UpdateTeamsLoginBody
+  }): Promise<ApiResponseV2<UpdateTeamsLogin200Data>>
+  deleteTeamsLogin(params: {
+    credential_id: string
+  }): Promise<ApiResponseV2<DeleteTeamsLogin200Data>>
   createZoomCredential(
     params: CreateZoomCredentialBody
   ): Promise<ApiResponseV2<CreateZoomCredential201Data>>

--- a/src/node/v2-methods.ts
+++ b/src/node/v2-methods.ts
@@ -20,6 +20,10 @@ import type {
   CreateMeetWorkspaceBody,
   CreateScheduledBotRequestBodyInput,
   CreateScheduledBotResponseData,
+  CreateTeamsLogin201Data,
+  CreateTeamsLoginBody,
+  CreateTeamsWorkspace201Data,
+  CreateTeamsWorkspaceBody,
   CreateZoomCredential201Data,
   CreateZoomCredentialBody,
   DeleteBotDataResponseData,
@@ -30,6 +34,8 @@ import type {
   DeleteMeetLogin200Data,
   DeleteMeetWorkspace200Data,
   DeleteScheduledBotResponseData,
+  DeleteTeamsLogin200Data,
+  DeleteTeamsWorkspace200Data,
   DeleteZoomCredential200Data,
   GetBotDetailsResponseData,
   GetBotScreenshotsResponseDataItem,
@@ -40,6 +46,9 @@ import type {
   GetMeetLoginUtilization200Data,
   GetMeetWorkspace200Data,
   GetScheduledBotResponseData,
+  GetTeamsLogin200Data,
+  GetTeamsLoginUtilization200Data,
+  GetTeamsWorkspace200Data,
   GetZoomCredential200Data,
   LeaveBotResponseData,
   ListBotsParams,
@@ -58,6 +67,10 @@ import type {
   ListRawCalendarsResponseDataItem,
   ListScheduledBotsParams,
   ListScheduledBotsResponseDataItem,
+  ListTeamsLogins200DataItem,
+  ListTeamsLoginsParams,
+  ListTeamsWorkspaces200DataItem,
+  ListTeamsWorkspacesParams,
   ListZoomCredentials200DataItem,
   ListZoomCredentialsParams,
   PauseBotRecording200Data,
@@ -86,6 +99,10 @@ import type {
   UpdateMeetWorkspaceBody,
   UpdateScheduledBotRequestBodyInput,
   UpdateScheduledBotResponseData,
+  UpdateTeamsLogin200Data,
+  UpdateTeamsLoginBody,
+  UpdateTeamsWorkspace200Data,
+  UpdateTeamsWorkspaceBody,
   UpdateZoomCredential200Data,
   UpdateZoomCredentialBody
 } from "../generated/v2/schema"
@@ -1084,6 +1101,206 @@ export function createV2Methods(state: ClientState): BaasClientV2Methods {
         (params: { credential_id: string }, options: AxiosRequestConfig) =>
           deleteMeetLoginApi(params.credential_id, options),
         deleteMeetLoginParams,
+        params,
+        state.getOptions()
+      )
+    },
+
+    // Teams workspace methods
+    async createTeamsWorkspace(
+      params: CreateTeamsWorkspaceBody
+    ): Promise<ApiResponseV2<CreateTeamsWorkspace201Data>> {
+      const { createTeamsWorkspace: createTeamsWorkspaceApi } = await import(
+        "../generated/v2/api/teams-workspaces/teams-workspaces.js"
+      )
+      const { createTeamsWorkspaceBody } = await import(
+        "../generated/v2/api/teams-workspaces/teams-workspaces.zod.js"
+      )
+
+      return apiWrapperV2<CreateTeamsWorkspace201Data, CreateTeamsWorkspaceBody>(
+        createTeamsWorkspaceApi,
+        createTeamsWorkspaceBody as z.ZodType<CreateTeamsWorkspaceBody>,
+        params,
+        state.getOptions()
+      )
+    },
+
+    async listTeamsWorkspaces(
+      params?: ListTeamsWorkspacesParams
+    ): Promise<ApiResponseV2<ListTeamsWorkspaces200DataItem[]>> {
+      const { listTeamsWorkspaces: listTeamsWorkspacesApi } = await import(
+        "../generated/v2/api/teams-workspaces/teams-workspaces.js"
+      )
+
+      return apiWrapperV2NoParams(
+        (options: AxiosRequestConfig) => listTeamsWorkspacesApi(params, options),
+        state.getOptions()
+      )
+    },
+
+    async getTeamsWorkspace(params: {
+      workspace_id: string
+    }): Promise<ApiResponseV2<GetTeamsWorkspace200Data>> {
+      const { getTeamsWorkspace: getTeamsWorkspaceApi } = await import(
+        "../generated/v2/api/teams-workspaces/teams-workspaces.js"
+      )
+      const { getTeamsWorkspaceParams } = await import(
+        "../generated/v2/api/teams-workspaces/teams-workspaces.zod.js"
+      )
+
+      return apiWrapperV2<GetTeamsWorkspace200Data, { workspace_id: string }>(
+        (params: { workspace_id: string }, options: AxiosRequestConfig) =>
+          getTeamsWorkspaceApi(params.workspace_id, options),
+        getTeamsWorkspaceParams,
+        params,
+        state.getOptions()
+      )
+    },
+
+    async updateTeamsWorkspace(params: {
+      workspace_id: string
+      body: UpdateTeamsWorkspaceBody
+    }): Promise<ApiResponseV2<UpdateTeamsWorkspace200Data>> {
+      const { updateTeamsWorkspace: updateTeamsWorkspaceApi } = await import(
+        "../generated/v2/api/teams-workspaces/teams-workspaces.js"
+      )
+      const { updateTeamsWorkspaceParams, updateTeamsWorkspaceBody } = await import(
+        "../generated/v2/api/teams-workspaces/teams-workspaces.zod.js"
+      )
+
+      return apiWrapperV2<
+        UpdateTeamsWorkspace200Data,
+        { workspace_id: string; body: UpdateTeamsWorkspaceBody }
+      >(
+        (params: { workspace_id: string; body: UpdateTeamsWorkspaceBody }, options) =>
+          updateTeamsWorkspaceApi(params.workspace_id, params.body, options),
+        z.object({
+          workspace_id: updateTeamsWorkspaceParams.shape.workspace_id,
+          body: updateTeamsWorkspaceBody
+        }) as z.ZodType<{ workspace_id: string; body: UpdateTeamsWorkspaceBody }>,
+        params,
+        state.getOptions()
+      )
+    },
+
+    async deleteTeamsWorkspace(params: {
+      workspace_id: string
+    }): Promise<ApiResponseV2<DeleteTeamsWorkspace200Data>> {
+      const { deleteTeamsWorkspace: deleteTeamsWorkspaceApi } = await import(
+        "../generated/v2/api/teams-workspaces/teams-workspaces.js"
+      )
+      const { deleteTeamsWorkspaceParams } = await import(
+        "../generated/v2/api/teams-workspaces/teams-workspaces.zod.js"
+      )
+
+      return apiWrapperV2<DeleteTeamsWorkspace200Data, { workspace_id: string }>(
+        (params: { workspace_id: string }, options: AxiosRequestConfig) =>
+          deleteTeamsWorkspaceApi(params.workspace_id, options),
+        deleteTeamsWorkspaceParams,
+        params,
+        state.getOptions()
+      )
+    },
+
+    // Teams login methods
+    async createTeamsLogin(
+      params: CreateTeamsLoginBody
+    ): Promise<ApiResponseV2<CreateTeamsLogin201Data>> {
+      const { createTeamsLogin: createTeamsLoginApi } = await import(
+        "../generated/v2/api/teams-logins/teams-logins.js"
+      )
+      const { createTeamsLoginBody } = await import(
+        "../generated/v2/api/teams-logins/teams-logins.zod.js"
+      )
+
+      return apiWrapperV2<CreateTeamsLogin201Data, CreateTeamsLoginBody>(
+        createTeamsLoginApi,
+        createTeamsLoginBody as z.ZodType<CreateTeamsLoginBody>,
+        params,
+        state.getOptions()
+      )
+    },
+
+    async listTeamsLogins(
+      params?: ListTeamsLoginsParams
+    ): Promise<ApiResponseV2<ListTeamsLogins200DataItem[]>> {
+      const { listTeamsLogins: listTeamsLoginsApi } = await import(
+        "../generated/v2/api/teams-logins/teams-logins.js"
+      )
+
+      return apiWrapperV2NoParams(
+        (options: AxiosRequestConfig) => listTeamsLoginsApi(params, options),
+        state.getOptions()
+      )
+    },
+
+    async getTeamsLoginUtilization(): Promise<ApiResponseV2<GetTeamsLoginUtilization200Data>> {
+      const { getTeamsLoginUtilization: getTeamsLoginUtilizationApi } = await import(
+        "../generated/v2/api/teams-logins/teams-logins.js"
+      )
+
+      return apiWrapperV2NoParams(getTeamsLoginUtilizationApi, state.getOptions())
+    },
+
+    async getTeamsLogin(params: {
+      credential_id: string
+    }): Promise<ApiResponseV2<GetTeamsLogin200Data>> {
+      const { getTeamsLogin: getTeamsLoginApi } = await import(
+        "../generated/v2/api/teams-logins/teams-logins.js"
+      )
+      const { getTeamsLoginParams } = await import(
+        "../generated/v2/api/teams-logins/teams-logins.zod.js"
+      )
+
+      return apiWrapperV2<GetTeamsLogin200Data, { credential_id: string }>(
+        (params: { credential_id: string }, options: AxiosRequestConfig) =>
+          getTeamsLoginApi(params.credential_id, options),
+        getTeamsLoginParams,
+        params,
+        state.getOptions()
+      )
+    },
+
+    async updateTeamsLogin(params: {
+      credential_id: string
+      body: UpdateTeamsLoginBody
+    }): Promise<ApiResponseV2<UpdateTeamsLogin200Data>> {
+      const { updateTeamsLogin: updateTeamsLoginApi } = await import(
+        "../generated/v2/api/teams-logins/teams-logins.js"
+      )
+      const { updateTeamsLoginParams, updateTeamsLoginBody } = await import(
+        "../generated/v2/api/teams-logins/teams-logins.zod.js"
+      )
+
+      return apiWrapperV2<
+        UpdateTeamsLogin200Data,
+        { credential_id: string; body: UpdateTeamsLoginBody }
+      >(
+        (params: { credential_id: string; body: UpdateTeamsLoginBody }, options) =>
+          updateTeamsLoginApi(params.credential_id, params.body, options),
+        z.object({
+          credential_id: updateTeamsLoginParams.shape.credential_id,
+          body: updateTeamsLoginBody
+        }) as z.ZodType<{ credential_id: string; body: UpdateTeamsLoginBody }>,
+        params,
+        state.getOptions()
+      )
+    },
+
+    async deleteTeamsLogin(params: {
+      credential_id: string
+    }): Promise<ApiResponseV2<DeleteTeamsLogin200Data>> {
+      const { deleteTeamsLogin: deleteTeamsLoginApi } = await import(
+        "../generated/v2/api/teams-logins/teams-logins.js"
+      )
+      const { deleteTeamsLoginParams } = await import(
+        "../generated/v2/api/teams-logins/teams-logins.zod.js"
+      )
+
+      return apiWrapperV2<DeleteTeamsLogin200Data, { credential_id: string }>(
+        (params: { credential_id: string }, options: AxiosRequestConfig) =>
+          deleteTeamsLoginApi(params.credential_id, options),
+        deleteTeamsLoginParams,
         params,
         state.getOptions()
       )

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -22,6 +22,8 @@ import { getBotsMock } from "../src/generated/v2/api/bots/bots.msw"
 import { getCalendarsMock as getV2CalendarsMock } from "../src/generated/v2/api/calendars/calendars.msw"
 import { getMeetLoginsMock } from "../src/generated/v2/api/meet-logins/meet-logins.msw"
 import { getMeetWorkspacesMock } from "../src/generated/v2/api/meet-workspaces/meet-workspaces.msw"
+import { getTeamsLoginsMock } from "../src/generated/v2/api/teams-logins/teams-logins.msw"
+import { getTeamsWorkspacesMock } from "../src/generated/v2/api/teams-workspaces/teams-workspaces.msw"
 import { getZoomCredentialsMock } from "../src/generated/v2/api/zoom-credentials/zoom-credentials.msw"
 
 // Note: Scheduled bot mocks are included in getBotsMock() (no separate scheduled-bots directory)
@@ -30,6 +32,8 @@ const v2Mocks: HttpHandler[] = [
   ...getV2CalendarsMock(),
   ...getMeetLoginsMock(),
   ...getMeetWorkspacesMock(),
+  ...getTeamsLoginsMock(),
+  ...getTeamsWorkspacesMock(),
   ...getZoomCredentialsMock()
 ]
 

--- a/test/unit/baas-client-v2.test.ts
+++ b/test/unit/baas-client-v2.test.ts
@@ -1349,6 +1349,56 @@ describe("BaasClient v2", () => {
       expect(result.success).toBe(true)
     })
 
+    it("should reject an invalid teams workspace domain before the request is sent", async () => {
+      let requestCount = 0
+
+      server.use(
+        http.post("https://api.meetingbaas.com/v2/teams-workspaces", () => {
+          requestCount++
+          return HttpResponse.json(createMockV2SuccessResponse({ workspace_id: workspaceId }), {
+            status: 201
+          })
+        })
+      )
+
+      const result = await client.createTeamsWorkspace({
+        name: "Contoso",
+        domain: "contoso"
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.code).toBe("VALIDATION_ERROR")
+        expect(result.statusCode).toBe(400)
+      }
+      expect(requestCount).toBe(0)
+    })
+
+    it("should reject an oversized teams workspace name before the request is sent", async () => {
+      let requestCount = 0
+
+      server.use(
+        http.post("https://api.meetingbaas.com/v2/teams-workspaces", () => {
+          requestCount++
+          return HttpResponse.json(createMockV2SuccessResponse({ workspace_id: workspaceId }), {
+            status: 201
+          })
+        })
+      )
+
+      const result = await client.createTeamsWorkspace({
+        name: "a".repeat(101),
+        domain: "contoso.onmicrosoft.com"
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.code).toBe("VALIDATION_ERROR")
+        expect(result.statusCode).toBe(400)
+      }
+      expect(requestCount).toBe(0)
+    })
+
     it("should infer teams workspace methods on v2 client", () => {
       expect(client).toHaveProperty("createTeamsWorkspace")
       expect(client).toHaveProperty("listTeamsWorkspaces")
@@ -1541,6 +1591,60 @@ describe("BaasClient v2", () => {
       const result = await client.deleteTeamsLogin({ credential_id: credentialId })
 
       expect(result.success).toBe(true)
+    })
+
+    it("should reject a malformed teams login workspace_id before the request is sent", async () => {
+      let requestCount = 0
+
+      server.use(
+        http.post("https://api.meetingbaas.com/v2/teams-logins", () => {
+          requestCount++
+          return HttpResponse.json(createMockV2SuccessResponse({ credential_id: credentialId }), {
+            status: 201
+          })
+        })
+      )
+
+      const result = await client.createTeamsLogin({
+        workspace_id: "not-a-uuid",
+        name: "bot1",
+        email: "bot1@contoso.onmicrosoft.com",
+        password: "s3cr3t-p@ss"
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.code).toBe("VALIDATION_ERROR")
+        expect(result.statusCode).toBe(400)
+      }
+      expect(requestCount).toBe(0)
+    })
+
+    it("should reject an invalid teams login email before the request is sent", async () => {
+      let requestCount = 0
+
+      server.use(
+        http.post("https://api.meetingbaas.com/v2/teams-logins", () => {
+          requestCount++
+          return HttpResponse.json(createMockV2SuccessResponse({ credential_id: credentialId }), {
+            status: 201
+          })
+        })
+      )
+
+      const result = await client.createTeamsLogin({
+        workspace_id: workspaceId,
+        name: "bot1",
+        email: "not-an-email",
+        password: "s3cr3t-p@ss"
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.code).toBe("VALIDATION_ERROR")
+        expect(result.statusCode).toBe(400)
+      }
+      expect(requestCount).toBe(0)
     })
 
     it("should infer teams login methods on v2 client", () => {

--- a/test/unit/baas-client-v2.test.ts
+++ b/test/unit/baas-client-v2.test.ts
@@ -1219,7 +1219,12 @@ describe("BaasClient v2", () => {
       })
 
       server.use(
-        http.post("https://api.meetingbaas.com/v2/teams-workspaces", () => {
+        http.post("https://api.meetingbaas.com/v2/teams-workspaces", async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>
+          expect(body).toEqual({
+            domain: "contoso.onmicrosoft.com",
+            name: "Contoso"
+          })
           return HttpResponse.json(mockResponse, { status: 201 })
         })
       )
@@ -1317,9 +1322,14 @@ describe("BaasClient v2", () => {
       })
 
       server.use(
-        http.patch(`https://api.meetingbaas.com/v2/teams-workspaces/${workspaceId}`, () => {
-          return HttpResponse.json(mockResponse, { status: 200 })
-        })
+        http.patch(
+          `https://api.meetingbaas.com/v2/teams-workspaces/${workspaceId}`,
+          async ({ request }) => {
+            const body = (await request.json()) as Record<string, unknown>
+            expect(body).toEqual({ name: "Contoso Renamed" })
+            return HttpResponse.json(mockResponse, { status: 200 })
+          }
+        )
       )
 
       const result = await client.updateTeamsWorkspace({
@@ -1424,7 +1434,14 @@ describe("BaasClient v2", () => {
       })
 
       server.use(
-        http.post("https://api.meetingbaas.com/v2/teams-logins", () => {
+        http.post("https://api.meetingbaas.com/v2/teams-logins", async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>
+          expect(body).toEqual({
+            workspace_id: workspaceId,
+            name: "bot1",
+            email: "bot1@contoso.onmicrosoft.com",
+            password: "s3cret-password"
+          })
           return HttpResponse.json(mockResponse, { status: 201 })
         })
       )
@@ -1561,9 +1578,14 @@ describe("BaasClient v2", () => {
       })
 
       server.use(
-        http.patch(`https://api.meetingbaas.com/v2/teams-logins/${credentialId}`, () => {
-          return HttpResponse.json(mockResponse, { status: 200 })
-        })
+        http.patch(
+          `https://api.meetingbaas.com/v2/teams-logins/${credentialId}`,
+          async ({ request }) => {
+            const body = (await request.json()) as Record<string, unknown>
+            expect(body).toEqual({ name: "bot1 renamed" })
+            return HttpResponse.json(mockResponse, { status: 200 })
+          }
+        )
       )
 
       const result = await client.updateTeamsLogin({
@@ -1593,7 +1615,7 @@ describe("BaasClient v2", () => {
       expect(result.success).toBe(true)
     })
 
-    it("should reject a malformed teams login workspace_id before the request is sent", async () => {
+    it("should reject a malformed teams login workspace_id before request is sent", async () => {
       let requestCount = 0
 
       server.use(

--- a/test/unit/baas-client-v2.test.ts
+++ b/test/unit/baas-client-v2.test.ts
@@ -1202,6 +1202,357 @@ describe("BaasClient v2", () => {
     })
   })
 
+  describe("Teams workspaces", () => {
+    const workspaceId = "44444444-4444-4444-8444-444444444444"
+
+    it("should create teams workspace successfully", async () => {
+      const mockResponse = createMockV2SuccessResponse({
+        workspace_id: workspaceId,
+        name: "Contoso",
+        domain: "contoso.onmicrosoft.com",
+        state: "active",
+        last_error_message: null,
+        last_error_at: null,
+        extra: null,
+        created_at: "2026-08-10T00:00:00Z",
+        updated_at: "2026-08-10T00:00:00Z"
+      })
+
+      server.use(
+        http.post("https://api.meetingbaas.com/v2/teams-workspaces", () => {
+          return HttpResponse.json(mockResponse, { status: 201 })
+        })
+      )
+
+      const result = await client.createTeamsWorkspace({
+        domain: "contoso.onmicrosoft.com",
+        name: "Contoso"
+      })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.workspace_id).toBe(workspaceId)
+        expect(result.data.domain).toBe("contoso.onmicrosoft.com")
+      }
+    })
+
+    it("should handle create teams workspace duplicate-domain error", async () => {
+      const mockError = createMockV2ErrorResponse(
+        "Workspace for this domain already exists",
+        "DUPLICATE_DOMAIN",
+        409
+      )
+
+      server.use(
+        http.post("https://api.meetingbaas.com/v2/teams-workspaces", () => {
+          return HttpResponse.json(mockError, { status: 409 })
+        })
+      )
+
+      const result = await client.createTeamsWorkspace({
+        domain: "contoso.onmicrosoft.com"
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.code).toBe("DUPLICATE_DOMAIN")
+        expect(result.statusCode).toBe(409)
+      }
+    })
+
+    it("should list teams workspaces successfully", async () => {
+      const mockResponse = createMockV2SuccessResponse([
+        {
+          workspace_id: workspaceId,
+          name: "Contoso",
+          domain: "contoso.onmicrosoft.com",
+          state: "active" as const
+        }
+      ])
+
+      server.use(
+        http.get("https://api.meetingbaas.com/v2/teams-workspaces", () => {
+          return HttpResponse.json(mockResponse, { status: 200 })
+        })
+      )
+
+      const result = await client.listTeamsWorkspaces()
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(Array.isArray(result.data)).toBe(true)
+        expect(result.data).toHaveLength(1)
+        expect(result.data[0].workspace_id).toBe(workspaceId)
+      }
+    })
+
+    it("should get teams workspace successfully", async () => {
+      const mockResponse = createMockV2SuccessResponse({
+        workspace_id: workspaceId,
+        name: "Contoso",
+        domain: "contoso.onmicrosoft.com",
+        state: "active"
+      })
+
+      server.use(
+        http.get(`https://api.meetingbaas.com/v2/teams-workspaces/${workspaceId}`, () => {
+          return HttpResponse.json(mockResponse, { status: 200 })
+        })
+      )
+
+      const result = await client.getTeamsWorkspace({ workspace_id: workspaceId })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.workspace_id).toBe(workspaceId)
+      }
+    })
+
+    it("should update teams workspace successfully", async () => {
+      const mockResponse = createMockV2SuccessResponse({
+        workspace_id: workspaceId,
+        name: "Contoso Renamed",
+        domain: "contoso.onmicrosoft.com",
+        state: "active"
+      })
+
+      server.use(
+        http.patch(`https://api.meetingbaas.com/v2/teams-workspaces/${workspaceId}`, () => {
+          return HttpResponse.json(mockResponse, { status: 200 })
+        })
+      )
+
+      const result = await client.updateTeamsWorkspace({
+        workspace_id: workspaceId,
+        body: { name: "Contoso Renamed" }
+      })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.name).toBe("Contoso Renamed")
+      }
+    })
+
+    it("should delete teams workspace successfully", async () => {
+      const mockResponse = createMockV2SuccessResponse({
+        message: "Workspace deleted"
+      })
+
+      server.use(
+        http.delete(`https://api.meetingbaas.com/v2/teams-workspaces/${workspaceId}`, () => {
+          return HttpResponse.json(mockResponse, { status: 200 })
+        })
+      )
+
+      const result = await client.deleteTeamsWorkspace({ workspace_id: workspaceId })
+
+      expect(result.success).toBe(true)
+    })
+
+    it("should infer teams workspace methods on v2 client", () => {
+      expect(client).toHaveProperty("createTeamsWorkspace")
+      expect(client).toHaveProperty("listTeamsWorkspaces")
+      expect(client).toHaveProperty("getTeamsWorkspace")
+      expect(client).toHaveProperty("updateTeamsWorkspace")
+      expect(client).toHaveProperty("deleteTeamsWorkspace")
+    })
+  })
+
+  describe("Teams logins", () => {
+    const workspaceId = "55555555-5555-4555-8555-555555555555"
+    const credentialId = "66666666-6666-4666-8666-666666666666"
+
+    it("should create teams login successfully", async () => {
+      const mockResponse = createMockV2SuccessResponse({
+        credential_id: credentialId,
+        workspace_id: workspaceId,
+        name: "bot1",
+        email: "bot1@contoso.onmicrosoft.com",
+        email_group: null,
+        state: "active",
+        active_session_count: 0
+      })
+
+      server.use(
+        http.post("https://api.meetingbaas.com/v2/teams-logins", () => {
+          return HttpResponse.json(mockResponse, { status: 201 })
+        })
+      )
+
+      const result = await client.createTeamsLogin({
+        workspace_id: workspaceId,
+        name: "bot1",
+        email: "bot1@contoso.onmicrosoft.com",
+        password: "s3cret-password"
+      })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.credential_id).toBe(credentialId)
+        expect(result.data.email).toBe("bot1@contoso.onmicrosoft.com")
+      }
+    })
+
+    it("should handle create teams login domain-mismatch error", async () => {
+      const mockError = createMockV2ErrorResponse(
+        "Email domain does not match workspace",
+        "DOMAIN_MISMATCH",
+        422
+      )
+
+      server.use(
+        http.post("https://api.meetingbaas.com/v2/teams-logins", () => {
+          return HttpResponse.json(mockError, { status: 422 })
+        })
+      )
+
+      const result = await client.createTeamsLogin({
+        workspace_id: workspaceId,
+        name: "bot1",
+        email: "bot1@contoso.onmicrosoft.com",
+        password: "s3cret-password"
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.code).toBe("DOMAIN_MISMATCH")
+        expect(result.statusCode).toBe(422)
+      }
+    })
+
+    it("should list teams logins successfully", async () => {
+      const mockResponse = createMockV2SuccessResponse([
+        {
+          credential_id: credentialId,
+          workspace_id: workspaceId,
+          name: "bot1",
+          email: "bot1@contoso.onmicrosoft.com",
+          email_group: null,
+          state: "active" as const,
+          active_session_count: 0
+        }
+      ])
+
+      server.use(
+        http.get("https://api.meetingbaas.com/v2/teams-logins", () => {
+          return HttpResponse.json(mockResponse, { status: 200 })
+        })
+      )
+
+      const result = await client.listTeamsLogins()
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(Array.isArray(result.data)).toBe(true)
+        expect(result.data).toHaveLength(1)
+      }
+    })
+
+    it("should get teams login utilization successfully", async () => {
+      const mockResponse = createMockV2SuccessResponse({
+        logins_total: 3,
+        logins_active: 3,
+        logins_invalid: 0,
+        concurrent_sessions: 12,
+        concurrent_capacity: 60,
+        utilization_pct: 20,
+        by_email_group: []
+      })
+
+      server.use(
+        http.get("https://api.meetingbaas.com/v2/teams-logins/utilization", () => {
+          return HttpResponse.json(mockResponse, { status: 200 })
+        })
+      )
+
+      const result = await client.getTeamsLoginUtilization()
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.concurrent_capacity).toBe(60)
+        expect(result.data.utilization_pct).toBe(20)
+      }
+    })
+
+    it("should get teams login successfully", async () => {
+      const mockResponse = createMockV2SuccessResponse({
+        credential_id: credentialId,
+        workspace_id: workspaceId,
+        name: "bot1",
+        email: "bot1@contoso.onmicrosoft.com",
+        email_group: null,
+        state: "active",
+        active_session_count: 0
+      })
+
+      server.use(
+        http.get(`https://api.meetingbaas.com/v2/teams-logins/${credentialId}`, () => {
+          return HttpResponse.json(mockResponse, { status: 200 })
+        })
+      )
+
+      const result = await client.getTeamsLogin({ credential_id: credentialId })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.credential_id).toBe(credentialId)
+      }
+    })
+
+    it("should update teams login successfully", async () => {
+      const mockResponse = createMockV2SuccessResponse({
+        credential_id: credentialId,
+        workspace_id: workspaceId,
+        name: "bot1 renamed",
+        email: "bot1@contoso.onmicrosoft.com",
+        email_group: null,
+        state: "active",
+        active_session_count: 0
+      })
+
+      server.use(
+        http.patch(`https://api.meetingbaas.com/v2/teams-logins/${credentialId}`, () => {
+          return HttpResponse.json(mockResponse, { status: 200 })
+        })
+      )
+
+      const result = await client.updateTeamsLogin({
+        credential_id: credentialId,
+        body: { name: "bot1 renamed" }
+      })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.name).toBe("bot1 renamed")
+      }
+    })
+
+    it("should delete teams login successfully", async () => {
+      const mockResponse = createMockV2SuccessResponse({
+        message: "Login deleted"
+      })
+
+      server.use(
+        http.delete(`https://api.meetingbaas.com/v2/teams-logins/${credentialId}`, () => {
+          return HttpResponse.json(mockResponse, { status: 200 })
+        })
+      )
+
+      const result = await client.deleteTeamsLogin({ credential_id: credentialId })
+
+      expect(result.success).toBe(true)
+    })
+
+    it("should infer teams login methods on v2 client", () => {
+      expect(client).toHaveProperty("createTeamsLogin")
+      expect(client).toHaveProperty("listTeamsLogins")
+      expect(client).toHaveProperty("getTeamsLogin")
+      expect(client).toHaveProperty("getTeamsLoginUtilization")
+      expect(client).toHaveProperty("updateTeamsLogin")
+      expect(client).toHaveProperty("deleteTeamsLogin")
+    })
+  })
+
   describe("response format", () => {
     it("should pass through v2 API response format without transformation", async () => {
       const botId = createMockBotId()


### PR DESCRIPTION
Exposes the Teams endpoint groups — already present in the generated layer since 6.2.1 — on the hand-written v2 client, following the meet-workspaces/meet-logins pattern from #31.

**Credit:** #33 by @amr-meetingbaas implemented this same wiring first (July 29). This PR is the rebased-onto-current-main equivalent (the generated layer has since landed on main via the 6.2.1 auto-publish, which put #33 into conflict). The four client-side zod validation tests are ported directly from #33 with co-author credit. Supersedes #33.

## Added client methods

**Teams workspaces** (Microsoft 365 tenants):
`createTeamsWorkspace`, `listTeamsWorkspaces`, `getTeamsWorkspace`, `updateTeamsWorkspace`, `deleteTeamsWorkspace`

**Teams logins** (per-tenant bot accounts; passwords write-only, `email_group` round-robin pooling):
`createTeamsLogin`, `listTeamsLogins`, `getTeamsLogin`, `getTeamsLoginUtilization`, `updateTeamsLogin`, `deleteTeamsLogin`

## Details
- Same lazy-import + zod-validated `apiWrapperV2` structure as the meet methods
- Teams MSW mocks registered in `test/setup.ts`
- 18 new unit tests: happy paths, duplicate-domain (409) and domain-mismatch (422) server errors, pre-request zod validation (invalid domain, oversized name, malformed workspace_id, invalid email — from #33), utilization metrics, method-presence assertions
- New `API-REFERENCE-V2.md` sections for both groups
- Version bumped to 6.2.2 so the auto-update workflow's pending-publish detection ships this to npm on the next run

## Verification
- `tsc --noEmit` clean
- 69/69 v2 client tests pass (full suite green in CI)

Not wired (intentionally, matches meet-sso precedent): the internal `/v2/teams-login/resolve-session` + `release-session` endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)